### PR TITLE
Nested Albums, and a whole lot more

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release Plugin
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Package plugin
+        run: |
+          # Copy .lrdevplugin to .lrplugin (distribution format)
+          cp -r LrLychee.lrdevplugin LrLychee.lrplugin
+
+          # Create zip archive
+          zip -r LrLychee.lrplugin.zip LrLychee.lrplugin/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: LrLychee.lrplugin.zip
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+LycheePlugin.log

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,356 @@
+# Development Notes
+
+Technical reference for working on the lr-lychee plugin. Covers Lightroom Classic SDK quirks and Lychee Gallery API details learned during development.
+
+## Adobe Lightroom Classic SDK
+
+### Plugin Structure
+
+- `Info.lua` — plugin manifest, declares `LrExportServiceProvider` pointing to the main provider file
+- `LycheePublishServiceProvider.lua` — all SDK callbacks (publish, collections, dialogs)
+- `LycheeAPI.lua` — HTTP client for Lychee's REST API
+
+### Key SDK Imports
+
+```lua
+local LrView = import 'LrView'           -- UI building
+local LrBinding = import 'LrBinding'     -- Observable data binding
+local LrDialogs = import 'LrDialogs'     -- Alert dialogs
+local LrTasks = import 'LrTasks'         -- Async tasks, sleep
+local LrHttp = import 'LrHttp'           -- HTTP requests
+local LrPathUtils = import 'LrPathUtils' -- File path manipulation
+local LrApplication = import 'LrApplication' -- Catalog access
+local LrErrors = import 'LrErrors'       -- Error handling
+local LrLogger = import 'LrLogger'       -- Logging (writes to ~/Documents/lrClassicLogs/)
+```
+
+### Publish Service Provider Properties
+
+```lua
+publishServiceProvider.exportPresetFields = { { key = 'field_name', default = '' } }
+publishServiceProvider.supportsIncrementalPublish = 'only'
+publishServiceProvider.canRenamePublishedCollection = true
+publishServiceProvider.canRenamePublishedCollectionSet = true
+publishServiceProvider.allowFileFormats = { 'JPEG', 'PNG' }
+publishServiceProvider.allowColorSpaces = { 'sRGB' }
+publishServiceProvider.canExportVideo = false
+```
+
+#### Section Visibility
+
+`showSections` acts as a **whitelist** — only listed sections appear. `hideSections` is a blacklist but is overridden by `showSections`. If you use `showSections`, every section you want visible must be listed:
+
+```lua
+publishServiceProvider.showSections = { 'fileNaming', 'imageSettings', 'outputSharpening', 'metadata' }
+publishServiceProvider.hideSections = { 'exportLocation', 'video' }
+```
+
+Available section IDs: `exportLocation`, `fileNaming`, `video`, `imageSettings`, `outputSharpening`, `metadata`, `watermarking`.
+
+### Callback Lifecycle
+
+#### Publishing
+
+1. `processRenderedPhotos(functionContext, exportContext)` — main upload loop
+   - Already runs in an async context (can yield)
+   - `exportContext.exportSession:countRenditions()` for count
+   - `exportContext:renditions { stopIfCanceled = true }` to iterate
+   - Each `rendition:waitForRender()` returns `(success, pathOrMessage)`
+   - `rendition.publishedPhotoId` — the stored remote ID (nil for new photos)
+   - `rendition.photo` — the LrPhoto object for metadata access
+   - `rendition:recordPublishedPhotoId(remoteId)` — store the remote ID after upload
+   - `rendition:uploadPhoto(...)` — NOT a real method; use your own API call
+   - The rendered file path already reflects any File Naming template the user configured
+
+#### Collections
+
+- `getCollectionBehaviorInfo(publishSettings)` — return table with `defaultCollectionName`, `canAddCollection`, `canAddCollectionSet`, etc.
+- `didCreateNewPublishedCollectionSet(publishSettings, info)` — called AFTER a collection set is created; `info.publishedCollectionSet`, `info.name`, `info.parents`
+- `deletePublishedCollectionSet(publishSettings, info)` — called to delete; `info.remoteId`, `info.name`
+- `renamePublishedCollection(publishSettings, info)` — `info.publishedCollection`, `info.name`
+- `renamePublishedCollectionSet(publishSettings, info)` — `info.publishedCollectionSet`, `info.remoteId`, `info.name`
+- `deletePhotosFromPublishedCollection(publishSettings, arrayOfPhotoIds, deletedCallback, localCollectionId)` — call `deletedCallback(photoId)` for each successfully deleted photo
+
+#### Collection Settings (Edit Published Collection Dialog)
+
+- `viewForCollectionSettings(f, publishSettings, info)` — **synchronous**, must return a view immediately
+  - `info.collectionSettings` — `LrObservableTable`, properties bound to UI controls update live
+  - `info.publishedCollection` — the published collection object (nil for new collections)
+  - `info.name` — collection name
+  - Use `LrTasks.startAsyncTask(function() ... end)` inside to fetch data from server
+  - Setting properties on `collectionSettings` from async task updates bound UI controls in real time
+
+- `updateCollectionSettings(publishSettings, info)` — called when user clicks OK
+  - `info.collectionSettings` — the final settings values
+  - `info.remoteId` — **often nil** for old collections; use fallback resolution
+  - `info.publishedCollection` — the collection object
+
+- `viewForCollectionSetSettings` / `updateCollectionSetSettings` — identical pattern for collection sets
+
+#### Key SDK Constraints (viewForCollectionSettings)
+
+1. **Must return view synchronously** — no yielding in the callback itself; use `startAsyncTask` for server calls
+2. **`popup_menu` `items` binding works** — `items = bind 'property_name'` updates the popup dynamically when the observable property changes (this is how header image photo list works)
+3. **`popup_menu` `value` binding works** — standard observable binding
+4. **`visible` binding on containers does NOT work** in this context — use `enabled` on individual controls instead
+5. **`enabled` binding on individual controls DOES work** — use for showing/hiding sub-options
+
+#### Collection URL
+
+- `getCollectionUrl(publishSettings, publishedCollectionInfo)` — **synchronous**, cannot yield
+  - `publishedCollectionInfo.remoteId` — may be nil
+  - Return a URL string or nil
+  - Returning nil shows "Can't find the URL" error dialog — return gallery root as fallback instead
+
+#### Remote ID Management
+
+- `publishedCollection:getRemoteId()` — must be called inside `catalog:withReadAccessDo()`
+- `publishedCollection:setRemoteId(id)` — must be called inside `catalog:withWriteAccessDo('reason', fn)`
+- `publishedCollection:setRemoteUrl(url)` — same write access requirement
+- Remote IDs can be nil for collections created before the plugin stored them — always have a fallback
+
+### LrObservableTable
+
+Properties set on an `LrObservableTable` (like `info.collectionSettings`) trigger UI updates on bound controls:
+
+```lua
+collectionSettings.description = 'new value'  -- Updates bound edit_field immediately
+collectionSettings.header_items = { ... }      -- Updates bound popup_menu items immediately
+```
+
+This works from async tasks too — the UI refreshes as soon as the property is set.
+
+### LrView UI Building
+
+```lua
+f:row { spacing = f:label_spacing(), ... }
+f:column { spacing = f:control_spacing(), fill_horizontal = 1, ... }
+f:group_box { title = 'Section', fill_horizontal = 1, ... }
+f:static_text { title = 'Label', alignment = 'right', width = LrView.share 'shared_width' }
+f:edit_field { value = bind 'prop', width_in_chars = 40 }
+f:popup_menu { value = bind 'prop', items = STATIC_TABLE, width = 200 }
+f:popup_menu { value = bind 'prop', items = bind 'dynamic_items_prop', width = 200 }
+f:checkbox { value = bind 'prop', title = 'Label', enabled = bind 'other_prop' }
+```
+
+`LrView.share 'name'` — share a width measurement across controls for alignment.
+
+### HTTP Requests (LrHttp)
+
+```lua
+LrHttp.get(url, headers, timeout)
+LrHttp.post(url, body, headers, timeout)
+LrHttp.post(url, body, headers, 'PATCH', timeout)  -- Method override for PATCH/DELETE
+LrHttp.post(url, body, headers, 'DELETE', timeout)
+LrHttp.postMultipart(url, content, headers, timeout)
+```
+
+- All return `(result, responseHeaders)`
+- `responseHeaders.status` contains the HTTP status code
+- For multipart uploads, set `skipContentType = true` on headers (postMultipart adds its own)
+
+### Logging
+
+```lua
+local logger = LrLogger('LycheePlugin')
+logger:enable('logfile')  -- Writes to ~/Documents/lrClassicLogs/LycheePlugin.log
+logger:info('message')
+logger:warn('message')
+logger:error('message')
+```
+
+### Catalog Access
+
+```lua
+local catalog = LrApplication.activeCatalog()
+
+-- Read access (for getRemoteId, etc.)
+catalog:withReadAccessDo(function()
+    local id = publishedCollection:getRemoteId()
+end)
+
+-- Write access (for setRemoteId, etc.)
+catalog:withWriteAccessDo('Reason string', function()
+    publishedCollection:setRemoteId(albumId)
+end)
+```
+
+**Important**: These calls yield, so they can only be used inside async tasks or other yielding contexts (like `processRenderedPhotos`).
+
+---
+
+## Lychee Gallery API (v7.x)
+
+Base URL: `{gallery_url}/api/v2`
+
+### Authentication
+
+All requests use Bearer token authentication:
+```
+Authorization: Bearer {api_token}
+```
+
+Token is generated in Lychee under user settings (Edit My User).
+
+### Endpoints
+
+#### Albums
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/Albums::tree` | Get full album tree |
+| GET | `/Album?album_id={id}` | Get album details (includes photos, editable, policy) |
+| POST | `/Album` | Create album (`title`, `parent_id`) |
+| PATCH | `/Album` | Update album properties |
+| POST | `/Album::move` | Move album to new parent |
+| DELETE | `/Album` | Delete album |
+
+#### Photos
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/Photo::upload` | Upload photo (multipart) |
+| PATCH | `/Photo` | Update photo metadata |
+| DELETE | `/Photo` | Delete photos |
+| POST | `/Photo::move` | Move photos between albums |
+
+#### Protection Policy
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/Album::updateProtectionPolicy` | Update visibility/access settings |
+
+### Album Details Response Structure
+
+`GET /Album?album_id={id}` returns:
+
+```json
+{
+  "resource": {
+    "id": "24-char-hex-string",
+    "title": "Album Name",
+    "description": "...",
+    "copyright": "...",
+    "photos": [
+      { "id": "24-char-hex", "title": "Photo Title", "original_name": "DSC_1234.jpg" }
+    ],
+    "editable": {
+      "license": "none|reserved|CC0|CC-BY-4.0|...",
+      "photo_sorting": { "column": "created_at|taken_at|title|...", "order": "ASC|DESC" },
+      "album_sorting": { "column": "created_at|title|...", "order": "ASC|DESC" },
+      "aspect_ratio": "5/4|4/3|3/2|16/9|1/1|2/3",
+      "photo_layout": "square|justified|masonry|grid|...",
+      "album_timeline": "...",
+      "photo_timeline": "...",
+      "header_id": null | "compact" | "24-char-photo-id",
+      "is_pinned": true|false
+    },
+    "policy": {
+      "is_public": true|false,
+      "is_link_required": true|false,
+      "is_nsfw": true|false,
+      "grants_full_photo_access": true|false,
+      "grants_download": true|false,
+      "is_password_required": true|false
+    }
+  }
+}
+```
+
+**Important**: Settings like `license`, `photo_sorting`, `aspect_ratio`, etc. are in `resource.editable`, NOT directly on `resource`.
+
+### PATCH /Album Required Fields
+
+When updating album properties, these fields are **required** even if unchanged:
+
+```json
+{
+  "album_id": "...",
+  "title": "...",
+  "is_compact": false,
+  "is_pinned": false,
+  "header_id": null
+}
+```
+
+- `is_compact` — derived from `header_id == 'compact'` (boolean)
+- `header_id` — null for default, or a 24-char photo ID for a specific header photo
+- When `is_compact` is true, `header_id` should be null
+- `is_pinned` — preserve from server (not exposed in our UI)
+
+### updateProtectionPolicy Required Fields
+
+```json
+{
+  "albumID": "...",
+  "is_public": false,
+  "is_link_required": false,
+  "is_nsfw": false,
+  "grants_full_photo_access": false,
+  "grants_download": false,
+  "is_password_required": false,
+  "grants_upload": false
+}
+```
+
+**Note**: `grants_upload` is required even though we don't expose it in the UI — always send `false`.
+
+### Photo Upload
+
+Multipart POST to `/Photo::upload`:
+- `album_id` — target album
+- File field with the photo data
+- Returns the uploaded photo's ID (after matching via album refresh)
+
+### Header Image States
+
+The `header_id` field has three possible states:
+
+1. **`null`** — default auto-generated header from album photos
+2. **`"compact"`** — no hero banner, just a compact title bar
+3. **`"24-char-photo-id"`** — specific album photo used as the hero banner
+
+In the PATCH request, this is split into two fields:
+- `is_compact = true` + `header_id = null` → compact mode
+- `is_compact = false` + `header_id = null` → default mode
+- `is_compact = false` + `header_id = "photo-id"` → specific photo
+
+### Album Tree Response
+
+`GET /Albums::tree` returns a flat list of albums with parent relationships. Each album has:
+- `id` — 24-character hex string
+- `title` — album name
+- `parent_id` — parent album ID or null for root
+
+---
+
+## Plugin Architecture Patterns
+
+### Remote ID Resolution
+
+Many old collections don't have a stored `remoteId`. The `resolveRemoteId` function handles this:
+
+1. Try `publishedCollection:getRemoteId()` via `catalog:withReadAccessDo()`
+2. If nil, fall back to `LycheeAPI.findAlbumByTitle(settings, name)`
+3. If found, store it back via `setRemoteId()` and `setRemoteUrl()` for future use
+
+### Duplicate Detection
+
+Before uploading, check if a photo with the same filename already exists in the album:
+
+1. Refresh album data via `getAlbumDetails()`
+2. Use `findPhotoByFilename()` to match by `original_name` or `title`
+3. Matching is normalized (case-insensitive, special chars stripped)
+4. If found, skip upload and use the existing photo's ID
+
+### Move Detection
+
+When republishing, if a photo's `publishedPhotoId` exists but isn't found in the current album's photo list, it was moved:
+
+1. Delete the photo from the old album
+2. Re-upload to the current album
+3. Update the stored remote ID
+
+### Known Photo ID Tracking
+
+The `knownPhotoIds` array tracks IDs of photos already in the album. This prevents the duplicate detection from matching a just-uploaded photo to itself when processing multiple photos in one publish batch.

--- a/LrLychee.lrdevplugin/Info.lua
+++ b/LrLychee.lrdevplugin/Info.lua
@@ -18,5 +18,5 @@ return {
         file = 'LycheePublishServiceProvider.lua',
     },
 
-    VERSION = { major = 1, minor = 1, revision = 0, build = 2 },
+    VERSION = { major = 1, minor = 2, revision = 0, build = 0 },
 }

--- a/LrLychee.lrdevplugin/Info.lua
+++ b/LrLychee.lrdevplugin/Info.lua
@@ -18,5 +18,5 @@ return {
         file = 'LycheePublishServiceProvider.lua',
     },
 
-    VERSION = { major = 1, minor = 0, revision = 0, build = 1 },
+    VERSION = { major = 1, minor = 1, revision = 0, build = 2 },
 }

--- a/LrLychee.lrdevplugin/LycheeAPI.lua
+++ b/LrLychee.lrdevplugin/LycheeAPI.lua
@@ -903,6 +903,98 @@ function LycheeAPI.updatePhoto(settings, photoId, albumId, metadata)
     return response or {}, nil
 end
 
+-- Update album settings (everything except title, which is handled by renameAlbum)
+-- Uses PATCH /Album with all editable properties
+function LycheeAPI.updateAlbumSettings(settings, albumId, albumData)
+    local url = getBaseUrl(settings) .. '/Album'
+    local headers = buildHeaders(settings)
+
+    local body = jsonEncode({
+        album_id = albumId,
+        title = albumData.title or '',
+        description = albumData.description or JSON_NULL,
+        license = albumData.license or 'none',
+        copyright = albumData.copyright or JSON_NULL,
+        photo_sorting_column = albumData.photo_sorting_column or JSON_NULL,
+        photo_sorting_order = albumData.photo_sorting_order or JSON_NULL,
+        album_sorting_column = albumData.album_sorting_column or JSON_NULL,
+        album_sorting_order = albumData.album_sorting_order or JSON_NULL,
+        album_aspect_ratio = albumData.album_aspect_ratio or JSON_NULL,
+        photo_layout = albumData.photo_layout or JSON_NULL,
+        album_timeline = albumData.album_timeline or JSON_NULL,
+        photo_timeline = albumData.photo_timeline or JSON_NULL,
+        -- Required by Lychee even if not changed
+        is_compact = albumData.is_compact or false,
+        is_pinned = albumData.is_pinned or false,
+        header_id = albumData.header_id or JSON_NULL,
+    })
+
+    logger:info('Updating album settings: ' .. body)
+
+    local result, respHeaders = LrHttp.post(url, body, headers, 'PATCH', 30)
+
+    if not result then
+        return false, 'Failed to update album settings (no response)'
+    end
+
+    local response = jsonDecode(result)
+    if type(response) == 'table' and (response.error or response.exception or response.errors) then
+        return false, 'Update failed: ' .. (response.message or response.exception or 'Unknown error')
+    end
+
+    return true, nil
+end
+
+-- Update album protection / visibility policy
+-- Uses POST /Album::updateProtectionPolicy
+function LycheeAPI.updateProtectionPolicy(settings, albumId, policyData)
+    local url = getBaseUrl(settings) .. '/Album::updateProtectionPolicy'
+    local headers = buildHeaders(settings)
+
+    local body = {
+        album_id = albumId,
+        is_public = policyData.is_public or false,
+        is_link_required = policyData.is_link_required or false,
+        is_nsfw = policyData.is_nsfw or false,
+        grants_full_photo_access = policyData.grants_full_photo_access or false,
+        grants_download = policyData.grants_download or false,
+        grants_upload = policyData.grants_upload or false,
+    }
+
+    -- Only include password field if explicitly provided
+    if policyData.password and policyData.password ~= '' then
+        body.password = policyData.password
+    end
+
+    local jsonBody = jsonEncode(body)
+    logger:info('Updating protection policy: ' .. jsonBody)
+
+    local result, respHeaders = LrHttp.post(url, jsonBody, headers, 30)
+
+    -- Lychee may return 204 No Content on success
+    if result == nil and respHeaders then
+        for _, h in ipairs(respHeaders) do
+            local field = h.field or h[1]
+            local value = h.value or h[2]
+            if field and field:lower() == 'status' then
+                local status = tonumber(tostring(value):match('%d+'))
+                if status and status >= 200 and status < 300 then
+                    return true, nil
+                end
+            end
+        end
+    end
+
+    if result and result ~= '' then
+        local response = jsonDecode(result)
+        if type(response) == 'table' and (response.error or response.exception or response.errors) then
+            return false, 'Update failed: ' .. (response.message or response.exception or 'Unknown error')
+        end
+    end
+
+    return true, nil
+end
+
 -- Expose findPhotoByFilename for use by the publish service provider
 LycheeAPI.findPhotoByFilename = findPhotoByFilename
 

--- a/LrLychee.lrdevplugin/LycheeAPI.lua
+++ b/LrLychee.lrdevplugin/LycheeAPI.lua
@@ -301,16 +301,66 @@ function LycheeAPI.findAlbumByTitle(settings, title)
     return nil, nil -- Not found, but no error
 end
 
+-- Find album by title scoped to a specific parent album
+-- If parentId is nil, searches top-level albums only
+-- Returns album table or nil
+function LycheeAPI.findAlbumByTitleUnderParent(settings, title, parentId)
+    if parentId then
+        -- Fetch the parent album and search its children
+        local albumDetails, err = LycheeAPI.getAlbumDetails(settings, parentId)
+        if not albumDetails then
+            return nil, err
+        end
+
+        -- Album details response has: resource.albums (child albums)
+        local resource = albumDetails.resource
+        if resource and resource.albums then
+            for _, album in ipairs(resource.albums) do
+                if album.title == title then
+                    return album, nil
+                end
+            end
+        end
+
+        -- Also check top-level albums field (response structure varies)
+        if albumDetails.albums then
+            for _, album in ipairs(albumDetails.albums) do
+                if album.title == title then
+                    return album, nil
+                end
+            end
+        end
+
+        return nil, nil -- Not found under this parent
+    else
+        -- No parent - search top-level albums only (not recursively)
+        local albums, err = LycheeAPI.getAlbums(settings)
+        if not albums then
+            return nil, err
+        end
+
+        if albums.albums then
+            for _, album in ipairs(albums.albums) do
+                if album.title == title then
+                    return album, nil
+                end
+            end
+        end
+
+        return nil, nil
+    end
+end
+
 -- Create a new album
 -- Returns the album ID as a string on success
 function LycheeAPI.createAlbum(settings, title, parentId)
     local url = getBaseUrl(settings) .. '/Album'
     local headers = buildHeaders(settings)
 
-    -- parent_id must be present - use empty string for root-level albums
+    -- parent_id must be present - use JSON null for root-level albums
     local bodyTable = {
         title = title,
-        parent_id = parentId or '',
+        parent_id = parentId or JSON_NULL,
     }
     local body = jsonEncode(bodyTable)
 
@@ -348,11 +398,11 @@ function LycheeAPI.createAlbum(settings, title, parentId)
     return nil, 'Invalid response from server: ' .. tostring(result)
 end
 
--- Find or create album by title
+-- Find or create album by title, optionally scoped to a parent album
 -- Returns album table with id and title fields
-function LycheeAPI.findOrCreateAlbum(settings, title)
-    -- First try to find existing album
-    local album, err = LycheeAPI.findAlbumByTitle(settings, title)
+function LycheeAPI.findOrCreateAlbum(settings, title, parentId)
+    -- First try to find existing album (scoped to parent if provided)
+    local album, err = LycheeAPI.findAlbumByTitleUnderParent(settings, title, parentId)
     if err then
         return nil, err
     end
@@ -361,8 +411,8 @@ function LycheeAPI.findOrCreateAlbum(settings, title)
         return album, nil
     end
 
-    -- Create new album - returns just the album ID
-    local albumId, createErr = LycheeAPI.createAlbum(settings, title, nil)
+    -- Create new album under the specified parent (or at root)
+    local albumId, createErr = LycheeAPI.createAlbum(settings, title, parentId)
     if createErr then
         return nil, createErr
     end
@@ -399,6 +449,104 @@ function LycheeAPI.renameAlbum(settings, albumId, newTitle)
     return true, nil
 end
 
+-- Move album(s) to a new parent album (or to root if newParentId is nil)
+-- Uses POST /Album::move with { album_id: destination, album_ids: [sources] }
+function LycheeAPI.moveAlbum(settings, albumId, newParentId)
+    local url = getBaseUrl(settings) .. '/Album::move'
+    local headers = buildHeaders(settings)
+
+    local body = jsonEncode({
+        album_id = newParentId or JSON_NULL,
+        album_ids = { albumId },
+    })
+
+    local result, respHeaders = LrHttp.post(url, body, headers, 30)
+
+    -- Lychee may return 204 No Content on success
+    if result == nil and respHeaders then
+        for _, h in ipairs(respHeaders) do
+            local field = h.field or h[1]
+            local value = h.value or h[2]
+            if field and field:lower() == 'status' then
+                local status = tonumber(tostring(value):match('%d+'))
+                if status and status >= 200 and status < 300 then
+                    return true, nil
+                end
+            end
+        end
+    end
+
+    if result and result ~= '' then
+        local response = jsonDecode(result)
+        if type(response) == 'table' and (response.error or response.exception) then
+            return false, response.message or 'Failed to move album'
+        end
+    end
+
+    return true, nil
+end
+
+-- Move photos to a different album
+-- Uses POST /Photo::move with { album_id: destination, photo_ids: [ids] }
+function LycheeAPI.movePhotos(settings, photoIds, targetAlbumId)
+    if not photoIds or #photoIds == 0 then
+        return true, nil
+    end
+
+    local url = getBaseUrl(settings) .. '/Photo::move'
+    local headers = buildHeaders(settings)
+
+    local body = jsonEncode({
+        album_id = targetAlbumId,
+        photo_ids = photoIds,
+    })
+
+    local result, respHeaders = LrHttp.post(url, body, headers, 30)
+
+    -- Lychee may return 204 No Content on success
+    if result == nil and respHeaders then
+        for _, h in ipairs(respHeaders) do
+            local field = h.field or h[1]
+            local value = h.value or h[2]
+            if field and field:lower() == 'status' then
+                local status = tonumber(tostring(value):match('%d+'))
+                if status and status >= 200 and status < 300 then
+                    return true, nil
+                end
+            end
+        end
+    end
+
+    if result and result ~= '' then
+        local response = jsonDecode(result)
+        if type(response) == 'table' and (response.error or response.exception) then
+            return false, response.message or 'Failed to move photos'
+        end
+    end
+
+    return true, nil
+end
+
+-- Get the parent album ID for a given album
+-- Returns parentId (string) or nil if album is at root
+function LycheeAPI.getAlbumParentId(settings, albumId)
+    local albumDetails, err = LycheeAPI.getAlbumDetails(settings, albumId)
+    if not albumDetails then
+        return nil, err
+    end
+
+    -- The album resource should have a parent_id field
+    local resource = albumDetails.resource or albumDetails
+    local parentId = resource.parent_id
+
+    -- parent_id may be null/nil for root-level albums
+    if parentId and parentId ~= '' then
+        return parentId, nil
+    end
+
+    return nil, nil
+end
+
 -- Get album details including photos
 function LycheeAPI.getAlbumDetails(settings, albumId)
     local url = getBaseUrl(settings) .. '/Album?album_id=' .. albumId
@@ -428,6 +576,7 @@ local function normalizeFilename(name)
 end
 
 -- Find a photo in album by original filename
+-- Also accessible as LycheeAPI.findPhotoByFilename for external use
 local function findPhotoByFilename(albumData, targetFilename)
     -- Album response has structure: { resource: { photos: [...] } }
     local resource = albumData.resource
@@ -627,6 +776,48 @@ function LycheeAPI.uploadPhoto(settings, filePath, albumId, knownPhotoIds)
     return nil, 'Upload succeeded but could not find photo ID in album for: ' .. fileName
 end
 
+-- Delete an album by ID
+-- Lychee cascades: all child albums and photos are also deleted
+function LycheeAPI.deleteAlbum(settings, albumId)
+    if not albumId or albumId == '' then
+        return true, nil
+    end
+
+    local url = getBaseUrl(settings) .. '/Album'
+    local headers = buildHeaders(settings)
+
+    local body = jsonEncode({
+        album_ids = { albumId },
+    })
+
+    -- Use LrHttp.post with DELETE method override
+    local result, respHeaders = LrHttp.post(url, body, headers, 'DELETE', 30)
+
+    -- Lychee returns 204 No Content on success (result may be empty)
+    if result == nil and respHeaders then
+        -- Check for successful status in headers
+        for _, h in ipairs(respHeaders) do
+            local field = h.field or h[1]
+            local value = h.value or h[2]
+            if field and field:lower() == 'status' then
+                local status = tonumber(tostring(value):match('%d+'))
+                if status and status >= 200 and status < 300 then
+                    return true, nil
+                end
+            end
+        end
+    end
+
+    if result and result ~= '' then
+        local response = jsonDecode(result)
+        if type(response) == 'table' and (response.error or response.exception) then
+            return false, response.message or 'Failed to delete album'
+        end
+    end
+
+    return true, nil
+end
+
 -- Delete photos by IDs
 -- API uses query parameters: photo_ids[]=id1&photo_ids[]=id2
 function LycheeAPI.deletePhotos(settings, photoIds)
@@ -711,5 +902,8 @@ function LycheeAPI.updatePhoto(settings, photoId, albumId, metadata)
 
     return response or {}, nil
 end
+
+-- Expose findPhotoByFilename for use by the publish service provider
+LycheeAPI.findPhotoByFilename = findPhotoByFilename
 
 return LycheeAPI

--- a/LrLychee.lrdevplugin/LycheeAPI.lua
+++ b/LrLychee.lrdevplugin/LycheeAPI.lua
@@ -306,28 +306,25 @@ end
 -- Returns album table or nil
 function LycheeAPI.findAlbumByTitleUnderParent(settings, title, parentId)
     if parentId then
-        -- Fetch the parent album and search its children
-        local albumDetails, err = LycheeAPI.getAlbumDetails(settings, parentId)
-        if not albumDetails then
-            return nil, err
+        -- Fetch child albums using Album::albums endpoint (Lychee 7.5+, returns { data: [...] })
+        local url = getBaseUrl(settings) .. '/Album::albums?album_id=' .. parentId
+        local headers = buildHeaders(settings)
+        local result = LrHttp.get(url, headers, 30)
+        if not result then
+            return nil, 'Failed to fetch child albums'
+        end
+        local albumsData = jsonDecode(result)
+        if not albumsData then
+            return nil, 'Invalid response fetching child albums'
+        end
+        if type(albumsData) == 'table' and (albumsData.error or albumsData.exception) then
+            return nil, albumsData.message or 'Failed to fetch child albums'
         end
 
-        -- Album details response has: resource.albums (child albums)
-        local resource = albumDetails.resource
-        if resource and resource.albums then
-            for _, album in ipairs(resource.albums) do
-                if album.title == title then
-                    return album, nil
-                end
-            end
-        end
-
-        -- Also check top-level albums field (response structure varies)
-        if albumDetails.albums then
-            for _, album in ipairs(albumDetails.albums) do
-                if album.title == title then
-                    return album, nil
-                end
+        local childAlbums = albumsData.data or {}
+        for _, album in ipairs(childAlbums) do
+            if album.title == title then
+                return album, nil
             end
         end
 
@@ -547,9 +544,9 @@ function LycheeAPI.getAlbumParentId(settings, albumId)
     return nil, nil
 end
 
--- Get album details including photos
+-- Get album details (metadata and parent info) - uses Album::head endpoint (Lychee 7.5+)
 function LycheeAPI.getAlbumDetails(settings, albumId)
-    local url = getBaseUrl(settings) .. '/Album?album_id=' .. albumId
+    local url = getBaseUrl(settings) .. '/Album::head?album_id=' .. albumId
     local headers = buildHeaders(settings)
 
     local result, respHeaders = LrHttp.get(url, headers, 30)
@@ -566,6 +563,29 @@ function LycheeAPI.getAlbumDetails(settings, albumId)
     return response, nil
 end
 
+-- Get photos in an album (paginated) - uses Album::photos endpoint (Lychee 7.5+)
+-- Returns { photos: [...], current_page, last_page, per_page, total } or nil, err
+function LycheeAPI.getAlbumPhotos(settings, albumId, page)
+    local url = getBaseUrl(settings) .. '/Album::photos?album_id=' .. albumId
+    if page and page > 1 then
+        url = url .. '&page=' .. page
+    end
+    local headers = buildHeaders(settings)
+
+    local result, respHeaders = LrHttp.get(url, headers, 30)
+
+    if not result then
+        return nil, 'Failed to get album photos'
+    end
+
+    local response = jsonDecode(result)
+    if type(response) == 'table' and (response.error or response.exception) then
+        return nil, response.message or 'Failed to get album photos'
+    end
+
+    return response, nil
+end
+
 -- Normalize filename for comparison (remove special chars, lowercase)
 local function normalizeFilename(name)
     if not name then return '' end
@@ -577,17 +597,11 @@ end
 
 -- Find a photo in album by original filename
 -- Also accessible as LycheeAPI.findPhotoByFilename for external use
+-- albumData is the response from getAlbumPhotos: { photos: [...] }
 local function findPhotoByFilename(albumData, targetFilename)
-    -- Album response has structure: { resource: { photos: [...] } }
-    local resource = albumData.resource
-    if not resource then
-        logger:warn('No resource in album data')
-        return nil
-    end
-
-    local photos = resource.photos
+    local photos = albumData.photos
     if not photos then
-        logger:warn('No photos in album resource')
+        logger:warn('No photos in album data')
         return nil
     end
 
@@ -724,12 +738,12 @@ function LycheeAPI.uploadPhoto(settings, filePath, albumId, knownPhotoIds)
             LrTasks.sleep(3) -- Longer wait between retries
         end
 
-        albumData, albumErr = LycheeAPI.getAlbumDetails(settings, albumIdStr)
+        albumData, albumErr = LycheeAPI.getAlbumPhotos(settings, albumIdStr)
         if not albumData then
             logger:warn('Album fetch attempt ' .. attempt .. ' failed: ' .. (albumErr or 'unknown'))
         else
             -- Get current photo count
-            local photos = albumData.resource and albumData.resource.photos or {}
+            local photos = albumData.photos or {}
             local currentCount = #photos
             logger:info('Album has ' .. currentCount .. ' photos (attempt ' .. attempt .. ')')
 

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -12,6 +12,7 @@ local LrProgressScope = import 'LrProgressScope'
 local LrPathUtils = import 'LrPathUtils'
 local LrBinding = import 'LrBinding'
 local LrLogger = import 'LrLogger'
+local LrErrors = import 'LrErrors'
 
 local logger = LrLogger('LycheePlugin')
 logger:enable('logfile')
@@ -50,7 +51,52 @@ function publishServiceProvider.getCollectionBehaviorInfo(publishSettings)
         defaultCollectionName = 'Photos',
         defaultCollectionCanBeDeleted = true,
         canAddCollection = true,
+        canAddCollectionSet = true,
     }
+end
+
+-- Helper to validate publish settings
+local function validateSettings(publishSettings)
+    if not publishSettings.gallery_url or publishSettings.gallery_url == '' then
+        return false
+    end
+    if not publishSettings.api_token or publishSettings.api_token == '' then
+        return false
+    end
+    return true
+end
+
+-- Walk the parents chain and ensure all ancestor albums exist on Lychee.
+-- Creates any missing ancestor albums automatically.
+-- Returns the innermost parent's Lychee album ID (or nil for root-level).
+local function ensureAncestorAlbums(publishSettings, parents)
+    if not parents or #parents == 0 then
+        return nil
+    end
+
+    local currentParentId = nil
+
+    -- parents is ordered outermost to innermost
+    for _, parent in ipairs(parents) do
+        if parent.remoteCollectionId and parent.remoteCollectionId ~= '' then
+            -- This ancestor already has a Lychee album ID
+            currentParentId = parent.remoteCollectionId
+            logger:info('Ancestor "' .. (parent.name or '?') .. '" already has remote ID: ' .. currentParentId)
+        else
+            -- This ancestor needs an album created (or found)
+            logger:info('Ancestor "' .. (parent.name or '?') .. '" has no remote ID, finding or creating...')
+            local album, err = LycheeAPI.findOrCreateAlbum(publishSettings, parent.name, currentParentId)
+            if album and album.id then
+                currentParentId = album.id
+                logger:info('Ancestor "' .. (parent.name or '?') .. '" resolved to album ID: ' .. currentParentId)
+            else
+                logger:warn('Failed to ensure ancestor "' .. (parent.name or '?') .. '": ' .. (err or 'unknown'))
+                -- Continue with current parent - best effort
+            end
+        end
+    end
+
+    return currentParentId
 end
 
 -- Settings UI at the top of the dialog
@@ -160,15 +206,52 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
             or 'Publishing 1 photo to Lychee',
     }
 
-    -- Find or create album for this collection
+    -- Resolve album for this collection
+    -- 1. If we already have a remoteId, use it directly (but check if it needs moving)
+    -- 2. Otherwise, ensure ancestor albums exist and find/create under the correct parent
     progressScope:setCaption('Finding or creating album...')
-    local album, albumErr = LycheeAPI.findOrCreateAlbum(publishSettings, collectionName)
-    if not album then
-        LrDialogs.message('Album Error', albumErr or 'Could not find or create album.', 'critical')
-        return
-    end
+    local albumId = publishedCollectionInfo.remoteId
 
-    local albumId = album.id
+    -- Determine the expected parent album from the collection set hierarchy
+    local expectedParentId = ensureAncestorAlbums(publishSettings, publishedCollectionInfo.parents)
+
+    if not albumId or albumId == '' then
+        -- No remote ID yet - find or create under the correct parent
+        local album, albumErr = LycheeAPI.findOrCreateAlbum(publishSettings, collectionName, expectedParentId)
+        if not album then
+            LrDialogs.message('Album Error', albumErr or 'Could not find or create album.', 'critical')
+            return
+        end
+
+        albumId = album.id
+    else
+        -- Album already exists on Lychee - check if it needs to be moved
+        -- (e.g. collection was dragged into/out of a collection set)
+        local currentParentId, parentErr = LycheeAPI.getAlbumParentId(publishSettings, albumId)
+        -- currentParentId is nil for root-level, a string for nested
+        -- expectedParentId is nil for root-level, a string for nested
+        local needsMove = false
+        if expectedParentId and currentParentId then
+            needsMove = (expectedParentId ~= currentParentId)
+        elseif expectedParentId or currentParentId then
+            -- One is nil and the other isn't: moving to/from root
+            needsMove = true
+        end
+
+        if needsMove then
+            logger:info('Album ' .. albumId .. ' needs moving: current parent=' ..
+                tostring(currentParentId) .. ', expected parent=' .. tostring(expectedParentId))
+            local moveOk, moveErr = LycheeAPI.moveAlbum(publishSettings, albumId, expectedParentId)
+            if moveOk then
+                logger:info('Successfully moved album ' .. albumId .. ' to parent ' .. tostring(expectedParentId))
+            else
+                LrDialogs.message('Move Warning',
+                    'Could not move album to its new location in Lychee: ' .. (moveErr or 'Unknown error') ..
+                    '\nPhotos will still be uploaded to the existing album.',
+                    'warning')
+            end
+        end
+    end
     if not albumId or albumId == '' then
         LrDialogs.message('Album Error', 'Album was found/created but no ID was returned.', 'critical')
         return
@@ -229,6 +312,39 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
             local title = photo:getFormattedMetadata('title')
             local caption = photo:getFormattedMetadata('caption')
 
+            -- Helper: check if a photo with this filename already exists in the album.
+            -- Returns the photo ID if found, nil otherwise.
+            local function findDuplicateInAlbum(fileName)
+                -- Refresh album data to catch recently-uploaded photos
+                local freshAlbumData = LycheeAPI.getAlbumDetails(publishSettings, albumId)
+                if freshAlbumData then
+                    local matchId = LycheeAPI.findPhotoByFilename(freshAlbumData, fileName)
+                    if matchId then
+                        logger:info('Found existing photo in album matching "' .. fileName .. '": ' .. matchId)
+                        return matchId
+                    end
+                end
+                return nil
+            end
+
+            -- Helper: upload a photo, but first check if it already exists in the album.
+            -- Returns { id = photoId } on success (whether matched or uploaded), or nil + error.
+            local function uploadOrMatchPhoto(filePath, fileName)
+                -- Check for an existing copy first
+                local existingId = findDuplicateInAlbum(fileName)
+                if existingId then
+                    -- Already in the album - skip upload, use the existing one
+                    logger:info('Skipping upload of "' .. fileName .. '" - already exists as ' .. existingId)
+                    if not knownPhotoData[existingId] then
+                        table.insert(knownPhotoIds, existingId)
+                    end
+                    return { id = existingId }, nil
+                end
+
+                -- Not found - do the upload
+                return LycheeAPI.uploadPhoto(publishSettings, filePath, albumId, knownPhotoIds)
+            end
+
             -- Helper function to update metadata after upload
             -- Uses existing Lychee data as fallback to avoid blanking fields
             local function updatePhotoMetadata(photoId)
@@ -259,67 +375,132 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
 
             if existingPhotoId then
                 -- Photo already exists on server
-                -- Check if this is just a metadata update or if the image was edited
-                local wasEdited = rendition.wasEditedSinceLastPublish
 
-                logger:info('Existing photo ID: ' .. tostring(existingPhotoId))
-                logger:info('Was edited since last publish: ' .. tostring(wasEdited))
-                logger:info('Title: ' .. tostring(title))
-                logger:info('Caption: ' .. tostring(caption))
+                -- Check if this photo is in a different album (collection was moved in LR).
+                -- knownPhotoIds/knownPhotoData were built from the current album's contents.
+                -- If the photo isn't there, it's in an old album and needs to be
+                -- deleted and re-uploaded to the current one.
+                local photoInCurrentAlbum = (knownPhotoData[existingPhotoId] ~= nil)
+                if not photoInCurrentAlbum then
+                    for _, kid in ipairs(knownPhotoIds) do
+                        if kid == existingPhotoId then
+                            photoInCurrentAlbum = true
+                            break
+                        end
+                    end
+                end
 
-                if wasEdited then
-                    -- Image was edited - delete old version and re-upload
-                    -- Lychee will read title/description/tags from EXIF on upload
-                    progressScope:setCaption(string.format('Re-uploading %s...', photoName))
+                if not photoInCurrentAlbum then
+                    -- Photo is in a different album - delete old copy and re-upload here
+                    logger:info('Photo ' .. existingPhotoId .. ' not in current album, re-uploading to new location')
+                    progressScope:setCaption(string.format('Relocating %s...', photoName))
 
-                    local deleteSuccess, deleteErr = LycheeAPI.deletePhotos(publishSettings, { existingPhotoId })
-                    if not deleteSuccess then
-                        table.insert(failures, {
-                            photo = photo,
-                            message = 'Failed to delete old version: ' .. (deleteErr or 'Unknown error'),
-                        })
-                    else
-                        -- Remove old ID from known list since we deleted it
-                        for idx, id in ipairs(knownPhotoIds) do
-                            if id == existingPhotoId then
-                                table.remove(knownPhotoIds, idx)
-                                break
+                    -- Check if this photo already exists in the current album (duplicate from prior attempt)
+                    local duplicateId = findDuplicateInAlbum(photoName)
+                    if duplicateId then
+                        -- Already in the target album - just adopt it
+                        logger:info('Photo already in target album as ' .. duplicateId .. ', skipping re-upload')
+                        -- Still delete the old copy from the source album
+                        if duplicateId ~= existingPhotoId then
+                            local deleteOk, deleteErr = LycheeAPI.deletePhotos(publishSettings, { existingPhotoId })
+                            if not deleteOk then
+                                logger:warn('Could not delete old copy of ' .. existingPhotoId .. ': ' .. (deleteErr or 'unknown'))
                             end
                         end
+                        rendition:recordPublishedPhotoId(duplicateId)
+                        rendition:recordPublishedPhotoUrl(
+                            publishSettings.gallery_url .. '/gallery/' .. albumId .. '/' .. duplicateId
+                        )
+                        updatePhotoMetadata(duplicateId)
+                    else
+                        -- Delete from old album (best effort - may fail if album was already deleted)
+                        local deleteOk, deleteErr = LycheeAPI.deletePhotos(publishSettings, { existingPhotoId })
+                        if not deleteOk then
+                            logger:warn('Could not delete old copy of ' .. existingPhotoId .. ': ' .. (deleteErr or 'unknown'))
+                        end
 
+                        -- Upload to the current album
                         local uploadResult, uploadErr = LycheeAPI.uploadPhoto(publishSettings, photoPath, albumId, knownPhotoIds)
 
                         if uploadResult and uploadResult.id then
-                            -- Add to known IDs for subsequent uploads
                             table.insert(knownPhotoIds, uploadResult.id)
                             rendition:recordPublishedPhotoId(uploadResult.id)
                             rendition:recordPublishedPhotoUrl(
                                 publishSettings.gallery_url .. '/gallery/' .. albumId .. '/' .. uploadResult.id
                             )
+                            -- Update metadata on the new copy
+                            updatePhotoMetadata(uploadResult.id)
                         else
                             table.insert(failures, {
                                 photo = photo,
-                                message = uploadErr or 'Unknown upload error',
+                                message = 'Failed to relocate photo: ' .. (uploadErr or 'Unknown error'),
                             })
                         end
                     end
                 else
-                    -- Only metadata changed - update via PATCH
-                    logger:info('Metadata-only update for photo: ' .. existingPhotoId)
-                    progressScope:setCaption(string.format('Updating metadata for %s...', photoName))
-                    updatePhotoMetadata(existingPhotoId)
-                    -- Must call recordPublishedPhotoId before recordPublishedPhotoUrl
-                    rendition:recordPublishedPhotoId(existingPhotoId)
-                    rendition:recordPublishedPhotoUrl(
-                        publishSettings.gallery_url .. '/gallery/' .. albumId .. '/' .. existingPhotoId
-                    )
+                    -- Photo is in the current album - normal update flow
+                    -- Check if this is just a metadata update or if the image was edited
+                    local wasEdited = rendition.wasEditedSinceLastPublish
+
+                    logger:info('Existing photo ID: ' .. tostring(existingPhotoId))
+                    logger:info('Was edited since last publish: ' .. tostring(wasEdited))
+                    logger:info('Title: ' .. tostring(title))
+                    logger:info('Caption: ' .. tostring(caption))
+
+                    if wasEdited then
+                        -- Image was edited - delete old version and re-upload
+                        -- Lychee will read title/description/tags from EXIF on upload
+                        progressScope:setCaption(string.format('Re-uploading %s...', photoName))
+
+                        local deleteSuccess, deleteErr = LycheeAPI.deletePhotos(publishSettings, { existingPhotoId })
+                        if not deleteSuccess then
+                            table.insert(failures, {
+                                photo = photo,
+                                message = 'Failed to delete old version: ' .. (deleteErr or 'Unknown error'),
+                            })
+                        else
+                            -- Remove old ID from known list since we deleted it
+                            for idx, id in ipairs(knownPhotoIds) do
+                                if id == existingPhotoId then
+                                    table.remove(knownPhotoIds, idx)
+                                    break
+                                end
+                            end
+
+                            local uploadResult, uploadErr = LycheeAPI.uploadPhoto(publishSettings, photoPath, albumId, knownPhotoIds)
+
+                            if uploadResult and uploadResult.id then
+                                -- Add to known IDs for subsequent uploads
+                                table.insert(knownPhotoIds, uploadResult.id)
+                                rendition:recordPublishedPhotoId(uploadResult.id)
+                                rendition:recordPublishedPhotoUrl(
+                                    publishSettings.gallery_url .. '/gallery/' .. albumId .. '/' .. uploadResult.id
+                                )
+                            else
+                                table.insert(failures, {
+                                    photo = photo,
+                                    message = uploadErr or 'Unknown upload error',
+                                })
+                            end
+                        end
+                    else
+                        -- Only metadata changed - update via PATCH
+                        logger:info('Metadata-only update for photo: ' .. existingPhotoId)
+                        progressScope:setCaption(string.format('Updating metadata for %s...', photoName))
+                        updatePhotoMetadata(existingPhotoId)
+                        -- Must call recordPublishedPhotoId before recordPublishedPhotoUrl
+                        rendition:recordPublishedPhotoId(existingPhotoId)
+                        rendition:recordPublishedPhotoUrl(
+                            publishSettings.gallery_url .. '/gallery/' .. albumId .. '/' .. existingPhotoId
+                        )
+                    end
                 end
             else
-                -- New photo - upload it
+                -- New photo - upload it (or match if already in album)
                 -- Lychee will read title/description/tags from EXIF on upload
                 progressScope:setCaption(string.format('Uploading %s...', photoName))
 
-                local uploadResult, uploadErr = LycheeAPI.uploadPhoto(publishSettings, photoPath, albumId, knownPhotoIds)
+                local uploadResult, uploadErr = uploadOrMatchPhoto(photoPath, photoName)
 
                 if uploadResult and uploadResult.id then
                     -- Add to known IDs for subsequent uploads
@@ -398,6 +579,84 @@ function publishServiceProvider.renamePublishedCollection(publishSettings, info)
 
     if albumId then
         -- Update album title via API
+        local success, err = LycheeAPI.renameAlbum(publishSettings, albumId, newName)
+        if not success then
+            LrDialogs.message('Rename Failed', err or 'Could not rename album in Lychee gallery.', 'warning')
+        end
+    end
+end
+
+-- Called after a new Published Collection Set is created
+function publishServiceProvider.didCreateNewPublishedCollectionSet(publishSettings, info)
+    if not validateSettings(publishSettings) then
+        return
+    end
+
+    -- Ensure all ancestor albums exist and get the parent album ID
+    local parentAlbumId = ensureAncestorAlbums(publishSettings, info.parents)
+
+    -- Create the album for this collection set
+    local albumId, err = LycheeAPI.createAlbum(publishSettings, info.name, parentAlbumId)
+    if not albumId then
+        LrDialogs.message('Album Creation Failed',
+            'Could not create album for collection set "' .. info.name .. '": ' .. (err or 'Unknown error'),
+            'warning')
+        return
+    end
+
+    logger:info('Created album for collection set "' .. info.name .. '": ' .. albumId)
+
+    -- Store the album ID on the collection set
+    info.publishedCollectionSet:setRemoteId(albumId)
+    info.publishedCollectionSet:setRemoteUrl(
+        publishSettings.gallery_url .. '/gallery/' .. albumId
+    )
+end
+
+-- Called when a Published Collection Set is being deleted
+function publishServiceProvider.deletePublishedCollectionSet(publishSettings, info)
+    if not validateSettings(publishSettings) then
+        return
+    end
+
+    local albumId = info.remoteId
+
+    if albumId and albumId ~= '' then
+        -- Warn the user about cascading delete
+        local result = LrDialogs.confirm(
+            'Delete Album from Lychee?',
+            'Deleting this collection set will also delete the album "' .. (info.name or '') ..
+            '" and ALL its sub-albums and photos from your Lychee gallery. This cannot be undone.',
+            'Delete',
+            'Cancel'
+        )
+
+        if result == 'cancel' then
+            LrErrors.throwCanceled()
+        end
+
+        local success, err = LycheeAPI.deleteAlbum(publishSettings, albumId)
+        if not success then
+            LrDialogs.message('Delete Failed',
+                err or 'Could not delete album from Lychee gallery.',
+                'critical')
+        else
+            logger:info('Deleted album for collection set "' .. (info.name or '') .. '": ' .. albumId)
+        end
+    end
+end
+
+-- Called when a Published Collection Set is being renamed
+function publishServiceProvider.renamePublishedCollectionSet(publishSettings, info)
+    local newName = info.name
+
+    if not validateSettings(publishSettings) then
+        return
+    end
+
+    local albumId = info.remoteId
+
+    if albumId then
         local success, err = LycheeAPI.renameAlbum(publishSettings, albumId, newName)
         if not success then
             LrDialogs.message('Rename Failed', err or 'Could not rename album in Lychee gallery.', 'warning')

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -1370,7 +1370,6 @@ publishServiceProvider.allowColorSpaces = { 'sRGB' }
 
 publishServiceProvider.hideSections = {
     'exportLocation',
-    'fileNaming',
     'video',
 }
 
@@ -1378,6 +1377,7 @@ publishServiceProvider.canExportVideo = false
 
 -- Hide the watermark section by default
 publishServiceProvider.showSections = {
+    'fileNaming',
     'imageSettings',
     'outputSharpening',
     'metadata',

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -23,6 +23,15 @@ local LycheeAPI = require 'LycheeAPI'
 
 local publishServiceProvider = {}
 
+-- Pending collection settings for albums that don't exist on Lychee yet.
+-- When a user creates a new collection with settings (description, visibility, etc.),
+-- updateCollectionSettings fires before the album is created. We snapshot the
+-- settings here so processRenderedPhotos can apply them after album creation.
+local pendingCollectionSettings = {}
+
+-- Forward declaration (defined later, but called from processRenderedPhotos)
+local saveAlbumSettingsToLychee
+
 -- Define the fields that will be stored in export presets
 publishServiceProvider.exportPresetFields = {
     { key = 'gallery_url', default = '' },
@@ -213,6 +222,7 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
     -- 2. Otherwise, ensure ancestor albums exist and find/create under the correct parent
     progressScope:setCaption('Finding or creating album...')
     local albumId = publishedCollectionInfo.remoteId
+    local isNewAlbum = not albumId or albumId == ''
 
     -- Determine the expected parent album from the collection set hierarchy
     local expectedParentId = ensureAncestorAlbums(publishSettings, publishedCollectionInfo.parents)
@@ -265,6 +275,16 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
         publishedCollectionInfo.publishedCollection:setRemoteUrl(
             publishSettings.gallery_url .. '/gallery/' .. albumId
         )
+    end
+
+    -- Apply pending collection settings for newly created albums.
+    -- When a user creates a new collection with settings (description, visibility, etc.),
+    -- updateCollectionSettings fires before the album exists on Lychee, so the settings
+    -- are stashed in pendingCollectionSettings. Apply them now that the album exists.
+    if isNewAlbum and pendingCollectionSettings[collectionName] then
+        logger:info('New album created — applying pending collection settings for "' .. collectionName .. '"')
+        saveAlbumSettingsToLychee(publishSettings, albumId, collectionName, pendingCollectionSettings[collectionName])
+        pendingCollectionSettings[collectionName] = nil
     end
 
     -- Get existing photo IDs and data in the album
@@ -613,6 +633,13 @@ function publishServiceProvider.didCreateNewPublishedCollectionSet(publishSettin
     info.publishedCollectionSet:setRemoteUrl(
         publishSettings.gallery_url .. '/gallery/' .. albumId
     )
+
+    -- Apply pending settings if the user configured them during creation
+    if pendingCollectionSettings[info.name] then
+        logger:info('Applying pending collection settings for set "' .. info.name .. '"')
+        saveAlbumSettingsToLychee(publishSettings, albumId, info.name, pendingCollectionSettings[info.name])
+        pendingCollectionSettings[info.name] = nil
+    end
 end
 
 -- Called when a Published Collection Set is being deleted
@@ -1078,8 +1105,8 @@ local function buildAlbumSettingsView(f, collectionSettings)
 end
 
 -- Helper: push album settings and protection policy to Lychee.
--- Called from updateCollectionSettings / updateCollectionSetSettings.
-local function saveAlbumSettingsToLychee(publishSettings, remoteId, collectionName, collectionSettings)
+-- Called from updateCollectionSettings / updateCollectionSetSettings / processRenderedPhotos.
+saveAlbumSettingsToLychee = function(publishSettings, remoteId, collectionName, collectionSettings)
     logger:info('saveAlbumSettingsToLychee called, remoteId=' .. tostring(remoteId) .. ', name=' .. tostring(collectionName))
     if not remoteId or remoteId == '' then
         logger:info('No remote album ID — skipping settings push (will apply on first publish)')
@@ -1276,7 +1303,34 @@ function publishServiceProvider.updateCollectionSettings(publishSettings, info)
         if (not remoteId or remoteId == '') and publishedCollection then
             remoteId = resolveRemoteId(publishedCollection, publishSettings, name)
         end
-        saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
+
+        if not remoteId or remoteId == '' then
+            -- Album doesn't exist yet — snapshot settings for processRenderedPhotos
+            logger:info('No remote album for "' .. name .. '" — saving settings for first publish')
+            pendingCollectionSettings[name] = {
+                description = collectionSettings.description,
+                license = collectionSettings.license,
+                copyright = collectionSettings.copyright,
+                photo_sorting_column = collectionSettings.photo_sorting_column,
+                photo_sorting_order = collectionSettings.photo_sorting_order,
+                album_sorting_column = collectionSettings.album_sorting_column,
+                album_sorting_order = collectionSettings.album_sorting_order,
+                album_aspect_ratio = collectionSettings.album_aspect_ratio,
+                photo_layout = collectionSettings.photo_layout,
+                album_timeline = collectionSettings.album_timeline,
+                photo_timeline = collectionSettings.photo_timeline,
+                header_id = collectionSettings.header_id,
+                is_public = collectionSettings.is_public,
+                is_link_required = collectionSettings.is_link_required,
+                is_nsfw = collectionSettings.is_nsfw,
+                grants_full_photo_access = collectionSettings.grants_full_photo_access,
+                grants_download = collectionSettings.grants_download,
+                is_password_required = collectionSettings.is_password_required,
+                password = collectionSettings.password,
+            }
+        else
+            saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
+        end
     end)
 end
 
@@ -1361,7 +1415,34 @@ function publishServiceProvider.updateCollectionSetSettings(publishSettings, inf
         if (not remoteId or remoteId == '') and publishedCollection then
             remoteId = resolveRemoteId(publishedCollection, publishSettings, name)
         end
-        saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
+
+        if not remoteId or remoteId == '' then
+            -- Album doesn't exist yet — snapshot settings for didCreateNewPublishedCollectionSet
+            logger:info('No remote album for set "' .. name .. '" — saving settings for creation')
+            pendingCollectionSettings[name] = {
+                description = collectionSettings.description,
+                license = collectionSettings.license,
+                copyright = collectionSettings.copyright,
+                photo_sorting_column = collectionSettings.photo_sorting_column,
+                photo_sorting_order = collectionSettings.photo_sorting_order,
+                album_sorting_column = collectionSettings.album_sorting_column,
+                album_sorting_order = collectionSettings.album_sorting_order,
+                album_aspect_ratio = collectionSettings.album_aspect_ratio,
+                photo_layout = collectionSettings.photo_layout,
+                album_timeline = collectionSettings.album_timeline,
+                photo_timeline = collectionSettings.photo_timeline,
+                header_id = collectionSettings.header_id,
+                is_public = collectionSettings.is_public,
+                is_link_required = collectionSettings.is_link_required,
+                is_nsfw = collectionSettings.is_nsfw,
+                grants_full_photo_access = collectionSettings.grants_full_photo_access,
+                grants_download = collectionSettings.grants_download,
+                is_password_required = collectionSettings.is_password_required,
+                password = collectionSettings.password,
+            }
+        else
+            saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
+        end
     end)
 end
 

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -583,6 +583,26 @@ function publishServiceProvider.deletePhotosFromPublishedCollection(publishSetti
     end
 end
 
+-- Called when a Published Collection is being deleted
+function publishServiceProvider.deletePublishedCollection(publishSettings, info)
+    if not validateSettings(publishSettings) then
+        return
+    end
+
+    local albumId = info.remoteId
+
+    if albumId and albumId ~= '' then
+        local success, err = LycheeAPI.deleteAlbum(publishSettings, albumId)
+        if not success then
+            LrDialogs.message('Delete Failed',
+                err or 'Could not delete album from Lychee gallery.',
+                'critical')
+        else
+            logger:info('Deleted album for collection "' .. (info.name or '') .. '": ' .. albumId)
+        end
+    end
+end
+
 -- Called when a published collection is being renamed
 function publishServiceProvider.renamePublishedCollection(publishSettings, info)
     local newName = info.name

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -702,6 +702,23 @@ end
 -- Album Settings (shown in Edit Published Collection / Collection Set dialog)
 --------------------------------------------------------------------------------
 
+-- Build header popup items from a photo list
+local function buildHeaderItems(photos)
+    local items = {
+        { title = '— Default', value = '' },
+        { title = 'Use compact header', value = 'compact' },
+    }
+    if photos then
+        for _, photo in ipairs(photos) do
+            if photo.id then
+                local label = photo.title or photo.id
+                items[#items + 1] = { title = label, value = photo.id }
+            end
+        end
+    end
+    return items
+end
+
 -- Popup items for album settings dropdowns
 local LICENSE_ITEMS = {
     { title = 'None', value = 'none' },
@@ -804,6 +821,8 @@ local function initCollectionSettingsDefaults(collectionSettings)
     if collectionSettings.grants_download == nil then collectionSettings.grants_download = false end
     if collectionSettings.is_password_required == nil then collectionSettings.is_password_required = false end
     if collectionSettings.password == nil then collectionSettings.password = '' end
+    if collectionSettings.header_id == nil then collectionSettings.header_id = '' end
+    if collectionSettings.header_items == nil then collectionSettings.header_items = buildHeaderItems(nil) end
     if collectionSettings.lychee_loaded == nil then collectionSettings.lychee_loaded = false end
 end
 
@@ -958,6 +977,21 @@ local function buildAlbumSettingsView(f, collectionSettings)
                         width = 120,
                     },
                 },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Header',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'header_id',
+                        items = bind 'header_items',
+                        width = 250,
+                    },
+                },
             },
         },
 
@@ -1051,13 +1085,18 @@ local function saveAlbumSettingsToLychee(publishSettings, remoteId, collectionNa
         return
     end
 
-    -- Fetch current album state to preserve fields we don't expose in UI
+    -- Fetch current album state to preserve is_pinned (not exposed in our UI)
     local albumData, fetchErr = LycheeAPI.getAlbumDetails(publishSettings, remoteId)
     local editable = {}
     if albumData then
         local resource = albumData.resource or albumData
         editable = resource.editable or {}
     end
+
+    -- Derive header fields from collectionSettings.header_id
+    local headerVal = collectionSettings.header_id or ''
+    local isCompact = headerVal == 'compact'
+    local headerPhotoId = (headerVal ~= '' and headerVal ~= 'compact') and headerVal or nil
 
     -- Save album properties
     local settingsData = {
@@ -1073,10 +1112,9 @@ local function saveAlbumSettingsToLychee(publishSettings, remoteId, collectionNa
         photo_layout = collectionSettings.photo_layout ~= '' and collectionSettings.photo_layout or nil,
         album_timeline = collectionSettings.album_timeline ~= '' and collectionSettings.album_timeline or nil,
         photo_timeline = collectionSettings.photo_timeline ~= '' and collectionSettings.photo_timeline or nil,
-        -- Preserve existing values for fields not in our UI
-        is_compact = editable.header_id == 'compact' or false,
+        is_compact = isCompact,
         is_pinned = editable.is_pinned or false,
-        header_id = (editable.header_id ~= 'compact') and editable.header_id or nil,
+        header_id = headerPhotoId,
     }
 
     local ok, err = LycheeAPI.updateAlbumSettings(publishSettings, remoteId, settingsData)
@@ -1166,7 +1204,6 @@ function publishServiceProvider.viewForCollectionSettings(f, publishSettings, in
         LrTasks.startAsyncTask(function()
             local remoteId = resolveRemoteId(publishedCollection, publishSettings, collectionName)
             if remoteId then
-                -- Call fetch directly (we're already in an async context)
                 logger:info('Fetching album settings for ' .. remoteId)
                 local albumData, fetchErr = LycheeAPI.getAlbumDetails(publishSettings, remoteId)
                 if not albumData then
@@ -1180,28 +1217,37 @@ function publishServiceProvider.viewForCollectionSettings(f, publishSettings, in
                 local photoSorting = editable.photo_sorting or {}
                 local albumSorting = editable.album_sorting or {}
 
+                -- Update header popup items with album photos (bound via observable)
+                local photos = resource.photos or {}
+                collectionSettings.header_items = buildHeaderItems(photos)
+                logger:info('Loaded ' .. #photos .. ' photos for header selection')
+
                 collectionSettings.description = resource.description or ''
                 collectionSettings.copyright = resource.copyright or ''
 
-                -- License: editable has the raw enum value (e.g. 'reserved'),
-                -- resource.license is the localized display string
                 local rawLicense = toVal(editable.license)
                 collectionSettings.license = rawLicense ~= '' and rawLicense or 'none'
 
-                -- Sorting: editable.photo_sorting / album_sorting are objects
-                -- with .column and .order sub-fields
                 collectionSettings.photo_sorting_column = toVal(photoSorting.column)
                 collectionSettings.photo_sorting_order = toVal(photoSorting.order)
                 collectionSettings.album_sorting_column = toVal(albumSorting.column)
                 collectionSettings.album_sorting_order = toVal(albumSorting.order)
 
-                -- Layout / aspect / timeline come from editable
                 collectionSettings.album_aspect_ratio = toVal(editable.aspect_ratio)
                 collectionSettings.photo_layout = toVal(editable.photo_layout)
                 collectionSettings.album_timeline = toVal(editable.album_timeline)
                 collectionSettings.photo_timeline = toVal(editable.photo_timeline)
 
-                -- Visibility flags from policy
+                -- Header: editable.header_id is 'compact', a photo ID, or nil
+                local hid = editable.header_id
+                if hid == 'compact' then
+                    collectionSettings.header_id = 'compact'
+                elseif hid and hid ~= '' then
+                    collectionSettings.header_id = hid
+                else
+                    collectionSettings.header_id = ''
+                end
+
                 collectionSettings.is_public = policy.is_public == true
                 collectionSettings.is_link_required = policy.is_link_required == true
                 collectionSettings.is_nsfw = policy.is_nsfw == true
@@ -1258,6 +1304,10 @@ function publishServiceProvider.viewForCollectionSetSettings(f, publishSettings,
                 local photoSorting = editable.photo_sorting or {}
                 local albumSorting = editable.album_sorting or {}
 
+                -- Update header popup items with album photos (bound via observable)
+                local photos = resource.photos or {}
+                collectionSettings.header_items = buildHeaderItems(photos)
+
                 collectionSettings.description = resource.description or ''
                 collectionSettings.copyright = resource.copyright or ''
 
@@ -1273,6 +1323,15 @@ function publishServiceProvider.viewForCollectionSetSettings(f, publishSettings,
                 collectionSettings.photo_layout = toVal(editable.photo_layout)
                 collectionSettings.album_timeline = toVal(editable.album_timeline)
                 collectionSettings.photo_timeline = toVal(editable.photo_timeline)
+
+                local hid = editable.header_id
+                if hid == 'compact' then
+                    collectionSettings.header_id = 'compact'
+                elseif hid and hid ~= '' then
+                    collectionSettings.header_id = hid
+                else
+                    collectionSettings.header_id = ''
+                end
 
                 collectionSettings.is_public = policy.is_public == true
                 collectionSettings.is_link_required = policy.is_link_required == true

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -21,6 +21,8 @@ logger:enable('logfile')
 
 local LycheeAPI = require 'LycheeAPI'
 
+local pluginVersion = '1.2.0'
+
 local publishServiceProvider = {}
 
 -- Pending collection settings for albums that don't exist on Lychee yet.
@@ -191,6 +193,7 @@ end
 
 -- Main function to process and upload rendered photos
 function publishServiceProvider.processRenderedPhotos(functionContext, exportContext)
+    logger:info('LrLychee v' .. pluginVersion .. ' — processRenderedPhotos started')
     local exportSession = exportContext.exportSession
     local publishSettings = exportContext.propertyTable
     local nPhotos = exportSession:countRenditions()
@@ -285,6 +288,8 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
     -- read settings directly from the Lightroom catalog as a fallback.
     if isNewAlbum then
         local settingsToApply = pendingCollectionSettings[collectionName]
+        logger:info('New album "' .. collectionName .. '": pendingCollectionSettings ' ..
+            (settingsToApply and 'found' or 'NOT found'))
 
         if not settingsToApply and publishedCollectionInfo.publishedCollection then
             -- Fallback: read settings directly from the collection in the catalog.
@@ -297,13 +302,21 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
                 if info and info.collectionSettings then
                     settingsToApply = info.collectionSettings
                     logger:info('Loaded collection settings from catalog for "' .. collectionName .. '"')
+                else
+                    logger:info('Catalog returned no collectionSettings for "' .. collectionName ..
+                        '" (info=' .. tostring(info ~= nil) .. ')')
                 end
             end)
+        elseif not settingsToApply then
+            logger:info('Cannot fall back to catalog: publishedCollection is nil for "' .. collectionName .. '"')
         end
 
         if settingsToApply then
             logger:info('New album created — applying collection settings for "' .. collectionName .. '"')
             saveAlbumSettingsToLychee(publishSettings, albumId, collectionName, settingsToApply)
+        else
+            logger:info('WARNING: No settings to apply for new album "' .. collectionName ..
+                '" — settings will need to be re-entered and published again')
         end
         pendingCollectionSettings[collectionName] = nil
     end

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -695,7 +695,8 @@ function publishServiceProvider.getCollectionUrl(publishSettings, publishedColle
         return publishSettings.gallery_url .. '/gallery/' .. remoteId
     end
 
-    return nil
+    -- No remoteId yet — return gallery root rather than nil (avoids error dialog)
+    return publishSettings.gallery_url
 end
 
 --------------------------------------------------------------------------------

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -15,6 +15,7 @@ local LrLogger = import 'LrLogger'
 local LrErrors = import 'LrErrors'
 local LrColor = import 'LrColor'
 local LrApplication = import 'LrApplication'
+local LrPrefs = import 'LrPrefs'
 
 local logger = LrLogger('LycheePlugin')
 logger:enable('logfile')
@@ -25,11 +26,21 @@ local pluginVersion = '1.2.0'
 
 local publishServiceProvider = {}
 
--- Pending collection settings for albums that don't exist on Lychee yet.
--- When a user creates a new collection with settings (description, visibility, etc.),
--- updateCollectionSettings fires before the album is created. We snapshot the
--- settings here so processRenderedPhotos can apply them after album creation.
-local pendingCollectionSettings = {}
+-- Helpers for persisting pending collection settings across Lightroom callback invocations.
+-- Lightroom re-executes this module file for each callback (fresh Lua state), so module-level
+-- tables reset between calls. LrPrefs is catalog-backed and survives across contexts.
+-- Keys are "pending_<name>"; entries are cleared after the first successful publish.
+local function storePendingSettings(name, settings)
+    LrPrefs.prefsForPlugin()['pending_' .. name] = settings
+end
+
+local function getPendingSettings(name)
+    return LrPrefs.prefsForPlugin()['pending_' .. name]
+end
+
+local function clearPendingSettings(name)
+    LrPrefs.prefsForPlugin()['pending_' .. name] = nil
+end
 
 -- Forward declaration (defined later, but called from processRenderedPhotos)
 local saveAlbumSettingsToLychee
@@ -281,20 +292,15 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
     end
 
     -- Apply collection settings for newly created albums.
-    -- When a user creates a new collection with settings (description, visibility, etc.),
-    -- updateCollectionSettings may fire before the album exists on Lychee, stashing the
-    -- settings in pendingCollectionSettings. However, the async task in updateCollectionSettings
-    -- may not have completed yet (or may not fire at all during creation), so we also
-    -- read settings directly from the Lightroom catalog as a fallback.
+    -- Settings are stored in LrPrefs by updateCollectionSettings (which runs in a separate
+    -- Lua state), retrieved here, applied to the newly created Lychee album, then cleared.
     if isNewAlbum then
-        local settingsToApply = pendingCollectionSettings[collectionName]
-        logger:info('New album "' .. collectionName .. '": pendingCollectionSettings ' ..
+        local settingsToApply = getPendingSettings(collectionName)
+        logger:info('New album "' .. collectionName .. '": prefs pending settings ' ..
             (settingsToApply and 'found' or 'NOT found'))
 
         if not settingsToApply and publishedCollectionInfo.publishedCollection then
-            -- Fallback: read settings directly from the collection in the catalog.
-            -- This handles the race condition where updateCollectionSettings' async task
-            -- hasn't populated pendingCollectionSettings yet, or wasn't called at all.
+            -- Fallback: read settings from the catalog if prefs entry is missing.
             logger:info('No pending settings found for "' .. collectionName .. '", reading from catalog...')
             local catalog = LrApplication.activeCatalog()
             catalog:withReadAccessDo(function()
@@ -318,7 +324,7 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
             logger:info('WARNING: No settings to apply for new album "' .. collectionName ..
                 '" — settings will need to be re-entered and published again')
         end
-        pendingCollectionSettings[collectionName] = nil
+        clearPendingSettings(collectionName)
     end
 
     -- Get existing photo IDs and data in the album
@@ -689,10 +695,11 @@ function publishServiceProvider.didCreateNewPublishedCollectionSet(publishSettin
     )
 
     -- Apply pending settings if the user configured them during creation
-    if pendingCollectionSettings[info.name] then
+    local pendingSet = getPendingSettings(info.name)
+    if pendingSet then
         logger:info('Applying pending collection settings for set "' .. info.name .. '"')
-        saveAlbumSettingsToLychee(publishSettings, albumId, info.name, pendingCollectionSettings[info.name])
-        pendingCollectionSettings[info.name] = nil
+        saveAlbumSettingsToLychee(publishSettings, albumId, info.name, pendingSet)
+        clearPendingSettings(info.name)
     end
 end
 
@@ -1352,39 +1359,45 @@ function publishServiceProvider.updateCollectionSettings(publishSettings, info)
     local name = info.name
     local publishedCollection = info.publishedCollection
 
+    -- Store settings in LrPrefs immediately so processRenderedPhotos can find them even though
+    -- each LR callback runs in a separate Lua state (module-level tables reset between calls).
+    storePendingSettings(name, {
+        description = collectionSettings.description,
+        license = collectionSettings.license,
+        copyright = collectionSettings.copyright,
+        photo_sorting_column = collectionSettings.photo_sorting_column,
+        photo_sorting_order = collectionSettings.photo_sorting_order,
+        album_sorting_column = collectionSettings.album_sorting_column,
+        album_sorting_order = collectionSettings.album_sorting_order,
+        album_aspect_ratio = collectionSettings.album_aspect_ratio,
+        photo_layout = collectionSettings.photo_layout,
+        album_timeline = collectionSettings.album_timeline,
+        photo_timeline = collectionSettings.photo_timeline,
+        header_id = collectionSettings.header_id,
+        is_public = collectionSettings.is_public,
+        is_link_required = collectionSettings.is_link_required,
+        is_nsfw = collectionSettings.is_nsfw,
+        grants_full_photo_access = collectionSettings.grants_full_photo_access,
+        grants_download = collectionSettings.grants_download,
+        is_password_required = collectionSettings.is_password_required,
+        password = collectionSettings.password,
+    })
+    logger:info('Stored pending settings in prefs for "' .. name .. '"')
+
     LrTasks.startAsyncTask(function()
         local remoteId = info.remoteId
         if (not remoteId or remoteId == '') and publishedCollection then
             remoteId = resolveRemoteId(publishedCollection, publishSettings, name)
         end
 
-        if not remoteId or remoteId == '' then
-            -- Album doesn't exist yet — snapshot settings for processRenderedPhotos
-            logger:info('No remote album for "' .. name .. '" — saving settings for first publish')
-            pendingCollectionSettings[name] = {
-                description = collectionSettings.description,
-                license = collectionSettings.license,
-                copyright = collectionSettings.copyright,
-                photo_sorting_column = collectionSettings.photo_sorting_column,
-                photo_sorting_order = collectionSettings.photo_sorting_order,
-                album_sorting_column = collectionSettings.album_sorting_column,
-                album_sorting_order = collectionSettings.album_sorting_order,
-                album_aspect_ratio = collectionSettings.album_aspect_ratio,
-                photo_layout = collectionSettings.photo_layout,
-                album_timeline = collectionSettings.album_timeline,
-                photo_timeline = collectionSettings.photo_timeline,
-                header_id = collectionSettings.header_id,
-                is_public = collectionSettings.is_public,
-                is_link_required = collectionSettings.is_link_required,
-                is_nsfw = collectionSettings.is_nsfw,
-                grants_full_photo_access = collectionSettings.grants_full_photo_access,
-                grants_download = collectionSettings.grants_download,
-                is_password_required = collectionSettings.is_password_required,
-                password = collectionSettings.password,
-            }
-        else
+        if remoteId and remoteId ~= '' then
+            -- Album already exists — push settings now and clear the prefs entry.
+            logger:info('Remote album found for "' .. name .. '" — applying settings immediately')
+            clearPendingSettings(name)
             saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
         end
+        -- If no remoteId the album doesn't exist yet; the prefs entry stays for
+        -- processRenderedPhotos to consume after it creates the album.
     end)
 end
 
@@ -1464,39 +1477,44 @@ function publishServiceProvider.updateCollectionSetSettings(publishSettings, inf
     local name = info.name
     local publishedCollection = info.publishedCollection
 
+    -- Store settings in LrPrefs immediately — same reasoning as updateCollectionSettings.
+    storePendingSettings(name, {
+        description = collectionSettings.description,
+        license = collectionSettings.license,
+        copyright = collectionSettings.copyright,
+        photo_sorting_column = collectionSettings.photo_sorting_column,
+        photo_sorting_order = collectionSettings.photo_sorting_order,
+        album_sorting_column = collectionSettings.album_sorting_column,
+        album_sorting_order = collectionSettings.album_sorting_order,
+        album_aspect_ratio = collectionSettings.album_aspect_ratio,
+        photo_layout = collectionSettings.photo_layout,
+        album_timeline = collectionSettings.album_timeline,
+        photo_timeline = collectionSettings.photo_timeline,
+        header_id = collectionSettings.header_id,
+        is_public = collectionSettings.is_public,
+        is_link_required = collectionSettings.is_link_required,
+        is_nsfw = collectionSettings.is_nsfw,
+        grants_full_photo_access = collectionSettings.grants_full_photo_access,
+        grants_download = collectionSettings.grants_download,
+        is_password_required = collectionSettings.is_password_required,
+        password = collectionSettings.password,
+    })
+    logger:info('Stored pending settings in prefs for set "' .. name .. '"')
+
     LrTasks.startAsyncTask(function()
         local remoteId = info.remoteId
         if (not remoteId or remoteId == '') and publishedCollection then
             remoteId = resolveRemoteId(publishedCollection, publishSettings, name)
         end
 
-        if not remoteId or remoteId == '' then
-            -- Album doesn't exist yet — snapshot settings for didCreateNewPublishedCollectionSet
-            logger:info('No remote album for set "' .. name .. '" — saving settings for creation')
-            pendingCollectionSettings[name] = {
-                description = collectionSettings.description,
-                license = collectionSettings.license,
-                copyright = collectionSettings.copyright,
-                photo_sorting_column = collectionSettings.photo_sorting_column,
-                photo_sorting_order = collectionSettings.photo_sorting_order,
-                album_sorting_column = collectionSettings.album_sorting_column,
-                album_sorting_order = collectionSettings.album_sorting_order,
-                album_aspect_ratio = collectionSettings.album_aspect_ratio,
-                photo_layout = collectionSettings.photo_layout,
-                album_timeline = collectionSettings.album_timeline,
-                photo_timeline = collectionSettings.photo_timeline,
-                header_id = collectionSettings.header_id,
-                is_public = collectionSettings.is_public,
-                is_link_required = collectionSettings.is_link_required,
-                is_nsfw = collectionSettings.is_nsfw,
-                grants_full_photo_access = collectionSettings.grants_full_photo_access,
-                grants_download = collectionSettings.grants_download,
-                is_password_required = collectionSettings.is_password_required,
-                password = collectionSettings.password,
-            }
-        else
+        if remoteId and remoteId ~= '' then
+            -- Album already exists — push settings now and clear the prefs entry.
+            logger:info('Remote album found for set "' .. name .. '" — applying settings immediately')
+            clearPendingSettings(name)
             saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
         end
+        -- If no remoteId the album doesn't exist yet; the prefs entry stays for
+        -- didCreateNewPublishedCollectionSet / processRenderedPhotos to consume.
     end)
 end
 

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -277,13 +277,34 @@ function publishServiceProvider.processRenderedPhotos(functionContext, exportCon
         )
     end
 
-    -- Apply pending collection settings for newly created albums.
+    -- Apply collection settings for newly created albums.
     -- When a user creates a new collection with settings (description, visibility, etc.),
-    -- updateCollectionSettings fires before the album exists on Lychee, so the settings
-    -- are stashed in pendingCollectionSettings. Apply them now that the album exists.
-    if isNewAlbum and pendingCollectionSettings[collectionName] then
-        logger:info('New album created — applying pending collection settings for "' .. collectionName .. '"')
-        saveAlbumSettingsToLychee(publishSettings, albumId, collectionName, pendingCollectionSettings[collectionName])
+    -- updateCollectionSettings may fire before the album exists on Lychee, stashing the
+    -- settings in pendingCollectionSettings. However, the async task in updateCollectionSettings
+    -- may not have completed yet (or may not fire at all during creation), so we also
+    -- read settings directly from the Lightroom catalog as a fallback.
+    if isNewAlbum then
+        local settingsToApply = pendingCollectionSettings[collectionName]
+
+        if not settingsToApply and publishedCollectionInfo.publishedCollection then
+            -- Fallback: read settings directly from the collection in the catalog.
+            -- This handles the race condition where updateCollectionSettings' async task
+            -- hasn't populated pendingCollectionSettings yet, or wasn't called at all.
+            logger:info('No pending settings found for "' .. collectionName .. '", reading from catalog...')
+            local catalog = LrApplication.activeCatalog()
+            catalog:withReadAccessDo(function()
+                local info = publishedCollectionInfo.publishedCollection:getCollectionInfoSummary()
+                if info and info.collectionSettings then
+                    settingsToApply = info.collectionSettings
+                    logger:info('Loaded collection settings from catalog for "' .. collectionName .. '"')
+                end
+            end)
+        end
+
+        if settingsToApply then
+            logger:info('New album created — applying collection settings for "' .. collectionName .. '"')
+            saveAlbumSettingsToLychee(publishSettings, albumId, collectionName, settingsToApply)
+        end
         pendingCollectionSettings[collectionName] = nil
     end
 

--- a/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
+++ b/LrLychee.lrdevplugin/LycheePublishServiceProvider.lua
@@ -13,6 +13,8 @@ local LrPathUtils = import 'LrPathUtils'
 local LrBinding = import 'LrBinding'
 local LrLogger = import 'LrLogger'
 local LrErrors = import 'LrErrors'
+local LrColor = import 'LrColor'
+local LrApplication = import 'LrApplication'
 
 local logger = LrLogger('LycheePlugin')
 logger:enable('logfile')
@@ -694,6 +696,613 @@ function publishServiceProvider.getCollectionUrl(publishSettings, publishedColle
     end
 
     return nil
+end
+
+--------------------------------------------------------------------------------
+-- Album Settings (shown in Edit Published Collection / Collection Set dialog)
+--------------------------------------------------------------------------------
+
+-- Popup items for album settings dropdowns
+local LICENSE_ITEMS = {
+    { title = 'None', value = 'none' },
+    { title = 'All Rights Reserved', value = 'reserved' },
+    { title = 'CC0 - Public Domain', value = 'CC0' },
+    { title = 'CC Attribution 4.0', value = 'CC-BY-4.0' },
+    { title = 'CC Attribution-ShareAlike 4.0', value = 'CC-BY-SA-4.0' },
+    { title = 'CC Attribution-NoDerivs 4.0', value = 'CC-BY-ND-4.0' },
+    { title = 'CC Attribution-NonCommercial 4.0', value = 'CC-BY-NC-4.0' },
+    { title = 'CC Attribution-NonCommercial-ShareAlike 4.0', value = 'CC-BY-NC-SA-4.0' },
+    { title = 'CC Attribution-NonCommercial-NoDerivs 4.0', value = 'CC-BY-NC-ND-4.0' },
+}
+
+local PHOTO_SORT_COLUMN_ITEMS = {
+    { title = '—', value = '' },
+    { title = 'Created at', value = 'created_at' },
+    { title = 'Taken at', value = 'taken_at' },
+    { title = 'Title', value = 'title' },
+    { title = 'Description', value = 'description' },
+    { title = 'Starred', value = 'is_starred' },
+    { title = 'Type', value = 'type' },
+}
+
+local ALBUM_SORT_COLUMN_ITEMS = {
+    { title = '—', value = '' },
+    { title = 'Created at', value = 'created_at' },
+    { title = 'Title', value = 'title' },
+    { title = 'Description', value = 'description' },
+    { title = 'Min taken at', value = 'min_taken_at' },
+    { title = 'Max taken at', value = 'max_taken_at' },
+}
+
+local SORT_ORDER_ITEMS = {
+    { title = '—', value = '' },
+    { title = 'Ascending', value = 'ASC' },
+    { title = 'Descending', value = 'DESC' },
+}
+
+local ASPECT_RATIO_ITEMS = {
+    { title = '—', value = '' },
+    { title = '1:1', value = '1/1' },
+    { title = '5:4', value = '5/4' },
+    { title = '3:2', value = '3/2' },
+    { title = '2:3', value = '2/3' },
+    { title = '4:5', value = '4/5' },
+    { title = '16:9', value = '16/9' },
+}
+
+local PHOTO_LAYOUT_ITEMS = {
+    { title = '—', value = '' },
+    { title = 'Square', value = 'square' },
+    { title = 'Justified', value = 'justified' },
+    { title = 'Masonry', value = 'masonry' },
+    { title = 'Grid', value = 'grid' },
+}
+
+local TIMELINE_ITEMS = {
+    { title = '—', value = '' },
+    { title = 'Default', value = 'default' },
+    { title = 'Disabled', value = 'disabled' },
+    { title = 'Year', value = 'year' },
+    { title = 'Month', value = 'month' },
+    { title = 'Day', value = 'day' },
+}
+
+local PHOTO_TIMELINE_ITEMS = {
+    { title = '—', value = '' },
+    { title = 'Default', value = 'default' },
+    { title = 'Disabled', value = 'disabled' },
+    { title = 'Year', value = 'year' },
+    { title = 'Month', value = 'month' },
+    { title = 'Day', value = 'day' },
+    { title = 'Hour', value = 'hour' },
+}
+
+-- Helper: convert nil / JSON null to empty string for popup bindings
+local function toVal(v)
+    if v == nil or v == '' then return '' end
+    return tostring(v)
+end
+
+-- Helper: set default values on collectionSettings for all album properties.
+-- These are the values used when creating a new collection (no remote album yet).
+local function initCollectionSettingsDefaults(collectionSettings)
+    if collectionSettings.description == nil then collectionSettings.description = '' end
+    if collectionSettings.license == nil then collectionSettings.license = 'none' end
+    if collectionSettings.copyright == nil then collectionSettings.copyright = '' end
+    if collectionSettings.photo_sorting_column == nil then collectionSettings.photo_sorting_column = '' end
+    if collectionSettings.photo_sorting_order == nil then collectionSettings.photo_sorting_order = '' end
+    if collectionSettings.album_sorting_column == nil then collectionSettings.album_sorting_column = '' end
+    if collectionSettings.album_sorting_order == nil then collectionSettings.album_sorting_order = '' end
+    if collectionSettings.album_aspect_ratio == nil then collectionSettings.album_aspect_ratio = '' end
+    if collectionSettings.photo_layout == nil then collectionSettings.photo_layout = '' end
+    if collectionSettings.album_timeline == nil then collectionSettings.album_timeline = '' end
+    if collectionSettings.photo_timeline == nil then collectionSettings.photo_timeline = '' end
+    if collectionSettings.is_public == nil then collectionSettings.is_public = false end
+    if collectionSettings.is_link_required == nil then collectionSettings.is_link_required = false end
+    if collectionSettings.is_nsfw == nil then collectionSettings.is_nsfw = false end
+    if collectionSettings.grants_full_photo_access == nil then collectionSettings.grants_full_photo_access = false end
+    if collectionSettings.grants_download == nil then collectionSettings.grants_download = false end
+    if collectionSettings.is_password_required == nil then collectionSettings.is_password_required = false end
+    if collectionSettings.password == nil then collectionSettings.password = '' end
+    if collectionSettings.lychee_loaded == nil then collectionSettings.lychee_loaded = false end
+end
+
+-- Build the album settings view (shared between collections and collection sets)
+local function buildAlbumSettingsView(f, collectionSettings)
+    local bind = LrView.bind
+
+    return f:column {
+        spacing = f:control_spacing(),
+        fill_horizontal = 1,
+        bind_to_object = collectionSettings,
+
+        -- Album Properties
+        f:group_box {
+            title = 'Lychee Album Settings',
+            fill_horizontal = 1,
+
+            f:column {
+                spacing = f:control_spacing(),
+                fill_horizontal = 1,
+
+                f:static_text {
+                    title = 'Description',
+                },
+                f:edit_field {
+                    value = bind 'description',
+                    fill_horizontal = 1,
+                    height_in_lines = 3,
+                    immediate = true,
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Order photos by',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'photo_sorting_column',
+                        items = PHOTO_SORT_COLUMN_ITEMS,
+                        width = 140,
+                    },
+                    f:popup_menu {
+                        value = bind 'photo_sorting_order',
+                        items = SORT_ORDER_ITEMS,
+                        width = 100,
+                    },
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Order albums by',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'album_sorting_column',
+                        items = ALBUM_SORT_COLUMN_ITEMS,
+                        width = 140,
+                    },
+                    f:popup_menu {
+                        value = bind 'album_sorting_order',
+                        items = SORT_ORDER_ITEMS,
+                        width = 100,
+                    },
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'License',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'license',
+                        items = LICENSE_ITEMS,
+                        width = 250,
+                    },
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Copyright',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:edit_field {
+                        value = bind 'copyright',
+                        fill_horizontal = 1,
+                        immediate = true,
+                    },
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Thumbs aspect ratio',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'album_aspect_ratio',
+                        items = ASPECT_RATIO_ITEMS,
+                        width = 100,
+                    },
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Photo layout',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'photo_layout',
+                        items = PHOTO_LAYOUT_ITEMS,
+                        width = 120,
+                    },
+                },
+
+                f:row {
+                    spacing = f:label_spacing(),
+
+                    f:static_text {
+                        title = 'Album timeline',
+                        alignment = 'right',
+                        width = LrView.share 'lychee_label_width',
+                    },
+                    f:popup_menu {
+                        value = bind 'album_timeline',
+                        items = TIMELINE_ITEMS,
+                        width = 120,
+                    },
+
+                    f:static_text {
+                        title = 'Photo timeline',
+                    },
+                    f:popup_menu {
+                        value = bind 'photo_timeline',
+                        items = PHOTO_TIMELINE_ITEMS,
+                        width = 120,
+                    },
+                },
+            },
+        },
+
+        -- Visibility & Access
+        f:group_box {
+            title = 'Visibility & Access',
+            fill_horizontal = 1,
+
+            f:column {
+                spacing = f:control_spacing(),
+                fill_horizontal = 1,
+
+                f:row {
+                    f:checkbox {
+                        title = 'Public',
+                        value = bind 'is_public',
+                    },
+                    f:static_text {
+                        title = '— Anonymous users can access this album',
+                        text_color = LrColor(0.6, 0.6, 0.6),
+                    },
+                },
+
+                -- Sub-options disabled when Public is off
+                f:column {
+                    margin_left = 20,
+                    spacing = f:control_spacing(),
+                    fill_horizontal = 1,
+
+                    f:checkbox {
+                        title = 'Original — View full-resolution photos',
+                        value = bind 'grants_full_photo_access',
+                        enabled = bind 'is_public',
+                    },
+                    f:checkbox {
+                        title = 'Hidden — Requires a direct link to access',
+                        value = bind 'is_link_required',
+                        enabled = bind 'is_public',
+                    },
+                    f:checkbox {
+                        title = 'Downloadable — Allow anonymous downloads',
+                        value = bind 'grants_download',
+                        enabled = bind 'is_public',
+                    },
+                    f:checkbox {
+                        title = 'Password protected',
+                        value = bind 'is_password_required',
+                        enabled = bind 'is_public',
+                    },
+
+                    f:row {
+                        margin_left = 20,
+                        spacing = f:label_spacing(),
+
+                        f:static_text {
+                            title = 'Password',
+                            enabled = bind 'is_password_required',
+                        },
+                        f:edit_field {
+                            value = bind 'password',
+                            width = 200,
+                            immediate = true,
+                            enabled = bind 'is_password_required',
+                        },
+                    },
+                },
+
+                f:separator { fill_horizontal = 1 },
+
+                f:row {
+                    f:checkbox {
+                        title = 'Sensitive',
+                        value = bind 'is_nsfw',
+                    },
+                    f:static_text {
+                        title = '— Album contains sensitive content',
+                        text_color = LrColor(0.6, 0.6, 0.6),
+                    },
+                },
+            },
+        },
+    }
+end
+
+-- Helper: push album settings and protection policy to Lychee.
+-- Called from updateCollectionSettings / updateCollectionSetSettings.
+local function saveAlbumSettingsToLychee(publishSettings, remoteId, collectionName, collectionSettings)
+    logger:info('saveAlbumSettingsToLychee called, remoteId=' .. tostring(remoteId) .. ', name=' .. tostring(collectionName))
+    if not remoteId or remoteId == '' then
+        logger:info('No remote album ID — skipping settings push (will apply on first publish)')
+        return
+    end
+
+    -- Fetch current album state to preserve fields we don't expose in UI
+    local albumData, fetchErr = LycheeAPI.getAlbumDetails(publishSettings, remoteId)
+    local editable = {}
+    if albumData then
+        local resource = albumData.resource or albumData
+        editable = resource.editable or {}
+    end
+
+    -- Save album properties
+    local settingsData = {
+        title = collectionName or '',
+        description = collectionSettings.description ~= '' and collectionSettings.description or nil,
+        license = collectionSettings.license or 'none',
+        copyright = collectionSettings.copyright ~= '' and collectionSettings.copyright or nil,
+        photo_sorting_column = collectionSettings.photo_sorting_column ~= '' and collectionSettings.photo_sorting_column or nil,
+        photo_sorting_order = collectionSettings.photo_sorting_order ~= '' and collectionSettings.photo_sorting_order or nil,
+        album_sorting_column = collectionSettings.album_sorting_column ~= '' and collectionSettings.album_sorting_column or nil,
+        album_sorting_order = collectionSettings.album_sorting_order ~= '' and collectionSettings.album_sorting_order or nil,
+        album_aspect_ratio = collectionSettings.album_aspect_ratio ~= '' and collectionSettings.album_aspect_ratio or nil,
+        photo_layout = collectionSettings.photo_layout ~= '' and collectionSettings.photo_layout or nil,
+        album_timeline = collectionSettings.album_timeline ~= '' and collectionSettings.album_timeline or nil,
+        photo_timeline = collectionSettings.photo_timeline ~= '' and collectionSettings.photo_timeline or nil,
+        -- Preserve existing values for fields not in our UI
+        is_compact = editable.header_id == 'compact' or false,
+        is_pinned = editable.is_pinned or false,
+        header_id = (editable.header_id ~= 'compact') and editable.header_id or nil,
+    }
+
+    local ok, err = LycheeAPI.updateAlbumSettings(publishSettings, remoteId, settingsData)
+    if not ok then
+        LrDialogs.message('Error', 'Failed to save album settings: ' .. (err or 'Unknown error'), 'critical')
+        return
+    end
+
+    -- Save protection policy
+    local policyUpdate = {
+        is_public = collectionSettings.is_public == true,
+        is_link_required = collectionSettings.is_link_required == true,
+        is_nsfw = collectionSettings.is_nsfw == true,
+        grants_full_photo_access = collectionSettings.grants_full_photo_access == true,
+        grants_download = collectionSettings.grants_download == true,
+        grants_upload = false, -- not exposed in UI, default to false
+    }
+
+    -- Only send password if user typed one
+    if collectionSettings.is_password_required and collectionSettings.password ~= '' then
+        policyUpdate.password = collectionSettings.password
+    end
+
+    local pOk, pErr = LycheeAPI.updateProtectionPolicy(publishSettings, remoteId, policyUpdate)
+    if not pOk then
+        LrDialogs.message('Error',
+            'Album properties saved, but failed to update visibility settings: '
+            .. (pErr or 'Unknown error'), 'critical')
+    end
+end
+
+-- Helper: get the remote album ID for a published collection/set.
+-- Tries getRemoteId() first, falls back to searching Lychee by name.
+-- Must be called from within an async task context.
+local function resolveRemoteId(publishedCollection, publishSettings, collectionName)
+    -- Try getRemoteId() from catalog
+    if publishedCollection then
+        local remoteId = nil
+        local catalog = LrApplication.activeCatalog()
+        catalog:withReadAccessDo(function()
+            remoteId = publishedCollection:getRemoteId()
+        end)
+
+        if remoteId and remoteId ~= '' then
+            logger:info('Got remoteId from catalog: ' .. tostring(remoteId))
+            return remoteId
+        end
+    end
+
+    -- Fallback: search Lychee by album name
+    if collectionName and collectionName ~= '' then
+        logger:info('remoteId not in catalog, searching Lychee for album "' .. collectionName .. '"')
+        local album, findErr = LycheeAPI.findAlbumByTitle(publishSettings, collectionName)
+        if album and album.id then
+            local albumId = album.id
+            logger:info('Found album by title: ' .. albumId)
+            -- Also fix the catalog so future lookups work
+            if publishedCollection then
+                local catalog = LrApplication.activeCatalog()
+                catalog:withWriteAccessDo('Set remote ID', function()
+                    publishedCollection:setRemoteId(albumId)
+                    publishedCollection:setRemoteUrl(
+                        publishSettings.gallery_url .. '/gallery/' .. albumId
+                    )
+                end)
+                logger:info('Stored remoteId in catalog for future use')
+            end
+            return albumId
+        else
+            logger:info('Could not find album by title: ' .. (findErr or 'not found'))
+        end
+    end
+
+    logger:info('No remote album ID found for collection')
+    return nil
+end
+
+-- SDK callback: build custom UI for the Create/Edit Published Collection dialog
+function publishServiceProvider.viewForCollectionSettings(f, publishSettings, info)
+    local collectionSettings = assert(info.collectionSettings)
+    initCollectionSettingsDefaults(collectionSettings)
+
+    -- Fetch from server inside an async task (where yielding is allowed)
+    local publishedCollection = info.publishedCollection
+    local collectionName = info.name
+    if publishedCollection then
+        LrTasks.startAsyncTask(function()
+            local remoteId = resolveRemoteId(publishedCollection, publishSettings, collectionName)
+            if remoteId then
+                -- Call fetch directly (we're already in an async context)
+                logger:info('Fetching album settings for ' .. remoteId)
+                local albumData, fetchErr = LycheeAPI.getAlbumDetails(publishSettings, remoteId)
+                if not albumData then
+                    logger:warn('Could not load album settings: ' .. (fetchErr or 'Unknown error'))
+                    return
+                end
+
+                local resource = albumData.resource or albumData
+                local policy = resource.policy or {}
+                local editable = resource.editable or {}
+                local photoSorting = editable.photo_sorting or {}
+                local albumSorting = editable.album_sorting or {}
+
+                collectionSettings.description = resource.description or ''
+                collectionSettings.copyright = resource.copyright or ''
+
+                -- License: editable has the raw enum value (e.g. 'reserved'),
+                -- resource.license is the localized display string
+                local rawLicense = toVal(editable.license)
+                collectionSettings.license = rawLicense ~= '' and rawLicense or 'none'
+
+                -- Sorting: editable.photo_sorting / album_sorting are objects
+                -- with .column and .order sub-fields
+                collectionSettings.photo_sorting_column = toVal(photoSorting.column)
+                collectionSettings.photo_sorting_order = toVal(photoSorting.order)
+                collectionSettings.album_sorting_column = toVal(albumSorting.column)
+                collectionSettings.album_sorting_order = toVal(albumSorting.order)
+
+                -- Layout / aspect / timeline come from editable
+                collectionSettings.album_aspect_ratio = toVal(editable.aspect_ratio)
+                collectionSettings.photo_layout = toVal(editable.photo_layout)
+                collectionSettings.album_timeline = toVal(editable.album_timeline)
+                collectionSettings.photo_timeline = toVal(editable.photo_timeline)
+
+                -- Visibility flags from policy
+                collectionSettings.is_public = policy.is_public == true
+                collectionSettings.is_link_required = policy.is_link_required == true
+                collectionSettings.is_nsfw = policy.is_nsfw == true
+                collectionSettings.grants_full_photo_access = policy.grants_full_photo_access == true
+                collectionSettings.grants_download = policy.grants_download == true
+                collectionSettings.is_password_required = policy.is_password_required == true
+                collectionSettings.password = ''
+
+                logger:info('Album settings loaded for ' .. remoteId)
+            end
+        end)
+    end
+
+    return buildAlbumSettingsView(f, collectionSettings)
+end
+
+-- SDK callback: save collection settings to Lychee when user clicks OK
+function publishServiceProvider.updateCollectionSettings(publishSettings, info)
+    local collectionSettings = assert(info.collectionSettings)
+    local name = info.name
+    local publishedCollection = info.publishedCollection
+
+    LrTasks.startAsyncTask(function()
+        local remoteId = info.remoteId
+        if (not remoteId or remoteId == '') and publishedCollection then
+            remoteId = resolveRemoteId(publishedCollection, publishSettings, name)
+        end
+        saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
+    end)
+end
+
+-- SDK callback: build custom UI for the Create/Edit Published Collection Set dialog
+function publishServiceProvider.viewForCollectionSetSettings(f, publishSettings, info)
+    local collectionSettings = assert(info.collectionSettings)
+    initCollectionSettingsDefaults(collectionSettings)
+
+    -- Fetch from server inside an async task (where yielding is allowed)
+    local publishedCollection = info.publishedCollection
+    local collectionName = info.name
+    if publishedCollection then
+        LrTasks.startAsyncTask(function()
+            local remoteId = resolveRemoteId(publishedCollection, publishSettings, collectionName)
+            if remoteId then
+                logger:info('Fetching album settings for set ' .. remoteId)
+                local albumData, fetchErr = LycheeAPI.getAlbumDetails(publishSettings, remoteId)
+                if not albumData then
+                    logger:warn('Could not load album settings: ' .. (fetchErr or 'Unknown error'))
+                    return
+                end
+
+                local resource = albumData.resource or albumData
+                local policy = resource.policy or {}
+                local editable = resource.editable or {}
+                local photoSorting = editable.photo_sorting or {}
+                local albumSorting = editable.album_sorting or {}
+
+                collectionSettings.description = resource.description or ''
+                collectionSettings.copyright = resource.copyright or ''
+
+                local rawLicense = toVal(editable.license)
+                collectionSettings.license = rawLicense ~= '' and rawLicense or 'none'
+
+                collectionSettings.photo_sorting_column = toVal(photoSorting.column)
+                collectionSettings.photo_sorting_order = toVal(photoSorting.order)
+                collectionSettings.album_sorting_column = toVal(albumSorting.column)
+                collectionSettings.album_sorting_order = toVal(albumSorting.order)
+
+                collectionSettings.album_aspect_ratio = toVal(editable.aspect_ratio)
+                collectionSettings.photo_layout = toVal(editable.photo_layout)
+                collectionSettings.album_timeline = toVal(editable.album_timeline)
+                collectionSettings.photo_timeline = toVal(editable.photo_timeline)
+
+                collectionSettings.is_public = policy.is_public == true
+                collectionSettings.is_link_required = policy.is_link_required == true
+                collectionSettings.is_nsfw = policy.is_nsfw == true
+                collectionSettings.grants_full_photo_access = policy.grants_full_photo_access == true
+                collectionSettings.grants_download = policy.grants_download == true
+                collectionSettings.is_password_required = policy.is_password_required == true
+                collectionSettings.password = ''
+
+                logger:info('Album settings loaded for set ' .. remoteId)
+            end
+        end)
+    end
+
+    return buildAlbumSettingsView(f, collectionSettings)
+end
+
+-- SDK callback: save collection set settings to Lychee when user clicks OK
+function publishServiceProvider.updateCollectionSetSettings(publishSettings, info)
+    local collectionSettings = assert(info.collectionSettings)
+    local name = info.name
+    local publishedCollection = info.publishedCollection
+
+    LrTasks.startAsyncTask(function()
+        local remoteId = info.remoteId
+        if (not remoteId or remoteId == '') and publishedCollection then
+            remoteId = resolveRemoteId(publishedCollection, publishSettings, name)
+        end
+        saveAlbumSettingsToLychee(publishSettings, remoteId, name, collectionSettings)
+    end)
 end
 
 -- Export file format settings

--- a/README.md
+++ b/README.md
@@ -1,19 +1,51 @@
 # Lightroom Classic Plugin: Lychee
 
-This project is a plugin for Adobe Lightroom Classic that synchronizes photos to a web gallery. It uses the Adobe Lightroom SDK to integrate with Lightroom Classic.
+A publish service plugin for Adobe Lightroom Classic that synchronizes photos to a [Lychee](https://lychee.electerious.com/) photo gallery. Each publish service gets its own connection (you can connect to several Lychee instances).
 
-Each publish service gets its own connection (you can connect to several Lychee instances) and can have several Publish Collections (maps to album on Lychee).
+## Features
+
+### Publishing
+
+- **Published Collections** — each collection maps to an album on Lychee
+- **Published Collection Sets** — nested collection sets map to nested albums, maintaining your folder hierarchy
+- **Photo upload** with automatic duplicate detection (skips photos already in the album)
+- **Metadata sync** — title, caption/description, and tags are pushed to Lychee on publish
+- **Republish on change** — editing a photo or changing its title/caption marks it for republish
+- **File renaming** — use Lightroom's File Naming options to control the uploaded filename
+- **Image sizing, sharpening, and metadata stripping** via standard Lightroom export panels
+
+### Collection & Album Management
+
+- **Create, rename, and delete** collections and collection sets from Lightroom
+- **Move detection** — moving a photo between collections in Lightroom will relocate it to the correct album on Lychee (delete + re-upload)
+- **Album settings** — edit album properties directly from Lightroom's "Edit Published Collection" dialog:
+  - Description, copyright, and license
+  - Photo and album sorting (column and order)
+  - Layout, aspect ratio, and timeline settings
+  - Header image selection (default, compact, or a specific album photo)
+  - Visibility and access controls: public/private, NSFW, link-required, full-size access, download permission, password protection
+- **"Go to Collection" URL** — right-click a collection and open it directly in your Lychee gallery
+
+### Connection
+
+- **Multiple instances** — add several publish services to connect to different Lychee galleries
+- **API token auth** — uses Bearer token authentication (generate a token under "Edit My User" in Lychee)
+- **Test Connection** button to verify your gallery URL and token
 
 ## Getting Started
 
 1. Install Adobe Lightroom Classic.
-2. Copy the `Lychee.lrdevplugin` folder to the Lightroom plugins directory (or add it where it is via Add Plugin)
+2. Copy the `LrLychee.lrdevplugin` folder to the Lightroom plugins directory (or add it via File > Plug-in Manager > Add).
 3. Enable the plugin in Lightroom Classic.
-4. Add a publish service - set the gallery URL and token (token can be generated under edit my user in Lychee)
-5. Add a publish collection and photos and publish.
+4. Under Publishing Manager, add a **Lychee Gallery** publish service — set the gallery URL and API token.
+5. Create a Published Collection, add photos, and click Publish.
+
+## Requirements
+
+- Adobe Lightroom Classic
+- Lychee v7.x
 
 ## Caveats
 
-- The code here is generated with claude code - my Lua skills and the state of the adobe documentation combined are not great :P
-- Only tested against lychee 7.x
-- So far - only album creation, upload of photo, and change of metadata (title, caption, tags) tested.
+- The code here is generated with AI assistance (Claude, Copilot, etc.) — my Lua skills and the state of the Adobe documentation combined are not great :P
+- Only tested against Lychee v7.x


### PR DESCRIPTION
This started as me trying to add support for nested album collections, and ended up with me effectively achieving feature parity with the useful parts of the SmugMug plugin. I've added a bunch of stuff:

1. Support for nested albums (collection sets)
2. Support for editing album settings directly in lightroom, including the headers <img width="636" height="798" alt="image" src="https://github.com/user-attachments/assets/c6f76a85-c76c-4e83-b5ad-5331805e5a19" />
3. Support for moving albums between different album sets (a little janky honestly but it gets the job done)
4. Support for file renaming on publish
5. Go to published collection works now <img width="365" height="113" alt="image" src="https://github.com/user-attachments/assets/8c194c08-e38e-483a-b747-644863e3d1c1" />
6. .lrplugin downloads get created upon release tags

I've tested it all to the best of my ability and it seems to work! Thanks for making the skeleton for the plugin. You've saved me hundreds on my about-to-renew smugmug subscription.